### PR TITLE
[WIP] Add simple mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ![logo](https://raw.githubusercontent.com/azerothcore/azerothcore.github.io/master/images/logo-github.png) AzerothCore
-- Latest build status with azerothcore: [![Build Status](https://travis-ci.org/azerothcore/mod-ah-bot.svg?branch=master)](https://travis-ci.org/azerothcore/mod-ah-bot)
-# Mod-AHBOT
+## Mod-AHBOT
+- Latest build status with azerothcore: [![Build Status](https://github.com/azerothcore/mod-ah-bot/workflows/core-build/badge.svg?branch=master&event=push)](https://github.com/azerothcore/mod-ah-bot)
+
 
 ## Important notes
 

--- a/TODO
+++ b/TODO
@@ -1,0 +1,9 @@
+✅Write sql script for schema
+Initialize + Keep item counts up to date    
+    ✅LoadValues: Init item counts from auction entry map
+    ✅Update map on increment + decrement
+    ✅Update seller to use item counts
+
+If we need more parameters: Create object to store item params, add new column to table
+Add command to add new item to auction house
+Switch off irrelevant code when simple mode is on

--- a/TODO
+++ b/TODO
@@ -3,7 +3,11 @@ Initialize + Keep item counts up to date
     ✅LoadValues: Init item counts from auction entry map
     ✅Update map on increment + decrement
     ✅Update seller to use item counts
+✅Add support for items without sell prices
+✅Add support for custom stack sizes
 
-If we need more parameters: Create object to store item params, add new column to table
 Add command to add new item to auction house
-Switch off irrelevant code when simple mode is on
+    Requires:
+        Add write support for adding rows to items table via code
+Cleanup: Run through + switch off redundant code when simple mode is on
+Add command to reload item config from DB

--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -15,6 +15,12 @@
 #        Enable/Disable the part of AHBot that puts items up for auction
 #    Default 0 (disabled)
 #
+#    AuctionHouseBot.SimpleSellerMode
+#        Enable/Disable Simple mode. 
+#        Simple mode will sell only a pre-programmed list of items 
+#        TODO: Explain further or rename
+#    Default 0 (disabled)
+#
 #    AuctionHouseBot.EnableBuyer
 #        Enable/Disable the part of AHBot that buys items from players
 #    Default 0 (disabled)
@@ -44,6 +50,7 @@
 AuctionHouseBot.DEBUG = 0
 AuctionHouseBot.DEBUG_FILTERS = 0
 AuctionHouseBot.EnableSeller = 0
+AuctionHouseBot.SimpleSellerMode = 1
 AuctionHouseBot.EnableBuyer = 0
 AuctionHouseBot.UseBuyPriceForSeller = 0
 AuctionHouseBot.UseBuyPriceForBuyer = 0

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -610,14 +610,14 @@ VALUES
 ,(40034, 3, 0) -- Guardian's Twilight Opal
 
 /* Jewelcrafting: Gems (Red) */
-,(40111, 3, 0) -- Bold Cardinal Ruby
-,(40112, 3, 0) -- Delicate Cardinal Ruby
-,(40113, 3, 0) -- Runed Cardinal Ruby
-,(40114, 3, 0) -- Bright Cardinal Ruby
-,(40115, 3, 0) -- Subtle Cardinal Ruby
-,(40116, 3, 0) -- Flashing Cardinal Ruby
-,(40117, 3, 0) -- Fractured Cardinal Ruby
-,(40118, 3, 0) -- Precise Cardinal Ruby
+,(40111, 1, 0) -- Bold Cardinal Ruby
+,(40112, 1, 0) -- Delicate Cardinal Ruby
+,(40113, 1, 0) -- Runed Cardinal Ruby
+,(40114, 1, 0) -- Bright Cardinal Ruby
+,(40115, 1, 0) -- Subtle Cardinal Ruby
+,(40116, 1, 0) -- Flashing Cardinal Ruby
+,(40117, 1, 0) -- Fractured Cardinal Ruby
+,(40118, 1, 0) -- Precise Cardinal Ruby
 
 ,(39996, 3, 0) -- Bold Scarlet Ruby
 ,(39997, 3, 0) -- Delicate Scarlet Ruby

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -108,6 +108,13 @@ VALUES
 ,(22572, 2, 0)
 ,(25707, 1, 0) -- (70)
 
+-- Leatherworking Mats Northrend
+
+,(33568, 3, 0) -- Borean Leather
+,(38558, 1, 0) -- Nerubian Chitin
+,(38561, 1, 0) -- Jormungar Scale
+,(38557, 1, 0) -- Icy Dragonscale
+
 -- ,(39686, 1, 0) -- Northrend
 -- ,(39682, 1, 0)
 -- ,(38558, 1, 0)
@@ -907,6 +914,21 @@ VALUES
 ,(35563, 1, 0) -- Charred Bear Kabobs
 ,(35565, 1, 0) -- Juicy Bear Burger
 ,(46691, 1, 0) -- Bread of the Dead
+
+/* Eternal elemtents and crystallized elements (Northrend)*/
+
+,(35622, 3, 0) -- Eternal Water
+,(35623, 3, 0) -- Eternal Air
+,(35624, 3, 0) -- Eternal Earth
+,(35625, 3, 0) -- Eternal Life
+,(35627, 3, 0) -- Eternal Shadow
+,(36860, 3, 0) -- Eternal Fire
+,(37700, 3, 0) -- Crystallized Air
+,(37701, 3, 0) -- Crystallized Earth
+,(37702, 3, 0) -- Crystallized Fire
+,(37703, 3, 0) -- Crystallized Shadow
+,(37704, 3, 0) -- Crystallized Life
+,(37705, 3, 0) -- Cryystallized Water
 
 ;
 

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -220,7 +220,7 @@ VALUES
 ,(34220, 3, 0) -- Chaotic Skyfire Diamond
 ,(24056, 3, 0) -- Glowing Nightseye
 ,(25893, 3, 0) -- Mystical Skyfire Diamond
-,(35945, 3, 0) -- Brilliant Glass
+-- ,(35945, 3, 0) -- Brilliant Glass -- Crafted by jewelcrafters + used by jewelcrafters - no sense selling on AH
 ,(24033, 3, 0) -- Solid Star of Elune
 ,(24065, 3, 0) -- Dazzling Talasite
 ,(32410, 3, 0) -- Thundering Skyfire Diamond
@@ -331,7 +331,7 @@ VALUES
 ,(23110, 3, 0) -- Shifting Shadow Draenite
 ,(23096, 3, 0) -- Runed Blood Garnet
 ,(23119, 3, 0) -- Sparkling Azure Moonstone
-,(45054, 3, 0) -- Prismatic Black Diamond
+-- ,(45054, 3, 0) -- Prismatic Black Diamond -- Jewelcrafting intermediary crafting item. No sense selling
 ,(23105, 3, 0) -- Enduring Deep Peridot
 ,(23114, 3, 0) -- Gleaming Golden Draenite
 ,(23099, 3, 0) -- Luminous Flame Spessarite
@@ -700,117 +700,16 @@ VALUES
 ,(37097, 1, 0) -- Scroll of Spirit VII
 ,(43465, 1, 0) -- Scroll of Strength VII
 
-,(43146, 1, 0) -- Weapon Vellum III
-,(43145, 1, 0) -- Armor Vellum III
-,(37602, 1, 0) -- Armor Vellum II
-,(39350, 1, 0) -- Weapon Vellum II
-,(38682, 1, 0) -- Armor Vellum
-,(39349, 1, 0) -- Weapon Vellum
-
-,(44317, 1, 0) -- Greater Darkmoon Card
-
-/* Enchanting: Used by other professions */
+/* Enchanting: Things that have prices */
 ,(12655, 1, 0) -- Enchanted Thorium Bar
 ,(12810, 1, 0) -- Enchanted Leather
 
-/* Enchanting: Enchants (70-50) */
-,(22459, 1, 1) -- (1) Void Sphere
-,(38921, 1, 1) -- Scroll of Enchant Weapon - Major Spellpower
-,(38946, 1, 1) -- Scroll of Enchant Weapon - Major Healing
-,(22460, 1, 1) -- Prismatic Sphere
-,(38920, 1, 1) -- Scroll of Enchant Weapon - Potency
-,(38919, 1, 1) -- Scroll of Enchant 2H Weapon - Savagery
-,(38947, 1, 1) -- Scroll of Enchant Weapon - Greater Agility
-,(38884, 1, 1) -- Scroll of Enchant Weapon - Mighty Intellect
-,(38888, 1, 1) -- Scroll of Enchant Gloves - Fire Power
-,(38895, 1, 1) -- Scroll of Enchant Cloak - Dodge
-,(38891, 1, 1) -- Scroll of Enchant Cloak - Greater Fire Resistance
-,(50816, 1, 1) -- Scroll of Enchant Gloves - Angler
-,(38886, 1, 1) -- Scroll of Enchant Gloves - Shadow Power
-,(38894, 1, 1) -- Scroll of Enchant Cloak - Subtlety
-,(38936, 1, 1) -- Scroll of Enchant Gloves - Major Healing
-,(38890, 1, 1) -- Scroll of Enchant Gloves - Superior Agility
-,(38885, 1, 1) -- Scroll of Enchant Gloves - Threat
-,(38893, 1, 1) -- Scroll of Enchant Cloak - Stealth
-,(38942, 1, 1) -- Scroll of Enchant Cloak - Greater Shadow Resistance
-,(38889, 1, 1) -- Scroll of Enchant Gloves - Healing Power
-,(38892, 1, 1) -- Scroll of Enchant Cloak - Greater Nature Resistance
-,(38941, 1, 1) -- Scroll of Enchant Cloak - Greater Arcane Resistance
-,(38902, 1, 1) -- Scroll of Enchant Bracer - Fortitude
-,(38887, 1, 1) -- Scroll of Enchant Gloves - Frost Power
-,(38913, 1, 1) -- Scroll of Enchant Chest - Exceptional Stats
-,(38930, 1, 1) -- Scroll of Enchant Chest - Major Resilience
-,(38917, 1, 1) -- Scroll of Enchant Weapon - Major Striking
-,(38918, 1, 1) -- Scroll of Enchant Weapon - Major Intellect
-,(38906, 1, 1) -- Scroll of Enchant Shield - Shield Block
 ,(22522, 1, 1) -- Superior Wizard Oil
-,(37603, 1, 1) -- Scroll of Enchant Boots - Dexterity
-,(38933, 1, 1) -- Scroll of Enchant Gloves - Major Strength
-,(38901, 1, 1) -- Scroll of Enchant Bracer - Restore Mana Prime
-,(38883, 1, 1) -- Scroll of Enchant Weapon - Mighty Spirit
-,(38915, 1, 1) -- Scroll of Enchant Cloak - Major Resistance
-,(38949, 1, 1) -- Scroll of Enchant Shield - Resilience
-,(38945, 1, 1) -- Scroll of Enchant Shield - Major Stamina
-,(38939, 1, 1) -- Scroll of Enchant Cloak - Spell Penetration
-,(38900, 1, 1) -- Scroll of Enchant Bracer - Superior Healing
-,(38905, 1, 1) -- Scroll of Enchant Shield - Intellect
-,(38928, 1, 1) -- Scroll of Enchant Chest - Major Spirit
-,(38882, 1, 1) -- Scroll of Enchant Bracer - Healing Power
-,(38899, 1, 1) -- Scroll of Enchant Bracer - Major Defense
-,(38909, 1, 1) -- Scroll of Enchant Boots - Fortitude
-,(38898, 1, 1) -- Scroll of Enchant Bracer - Stats
-,(38911, 1, 1) -- Scroll of Enchant Chest - Exceptional Health
-,(38871, 1, 1) -- Scroll of Enchant Weapon - Lifestealing
-,(38874, 1, 1) -- Scroll of Enchant 2H Weapon - Major Spirit
-,(38904, 1, 1) -- Scroll of Enchant Shield - Tough Shield
-,(38940, 1, 1) -- Scroll of Enchant Cloak - Greater Agility
-
-,(38865, 1, 1) -- (51) Scroll of Enchant Chest - Greater Stats
-,(38934, 1, 1) -- Scroll of Enchant Gloves - Assault
-,(38914, 1, 1) -- Scroll of Enchant Cloak - Major Armor
 ,(22521, 1, 1) -- Superior Mana Oil
-,(38873, 1, 1) -- Scroll of Enchant Weapon - Crusader
-,(38937, 1, 1) -- Scroll of Enchant Bracer - Major Intellect
-,(38908, 1, 1) -- Scroll of Enchant Boots - Vitality
-,(38931, 1, 1) -- Scroll of Enchant Gloves - Blasting
-,(38897, 1, 1) -- Scroll of Enchant Bracer - Brawn
-,(38875, 1, 1) -- Scroll of Enchant 2H Weapon - Major Intellect
-,(38870, 1, 1) -- Scroll of Enchant Weapon - Superior Striking
-,(38878, 1, 1) -- Scroll of Enchant Weapon - Healing Power
-,(38877, 1, 1) -- Scroll of Enchant Weapon - Spellpower
-,(38855, 1, 1) -- Scroll of Enchant Bracer - Superior Stamina
-,(38929, 1, 1) -- Scroll of Enchant Chest - Restore Mana Prime
-,(38938, 1, 1) -- Scroll of Enchant Bracer - Assault
-,(38869, 1, 1) -- Scroll of Enchant 2H Weapon - Superior Impact
-,(38872, 1, 1) -- Scroll of Enchant Weapon - Unholy Weapon
-,(38863, 1, 1) -- Scroll of Enchant Boots - Greater Agility
-,(38854, 1, 1) -- Scroll of Enchant Bracer - Superior Strength
-,(38857, 1, 1) -- Scroll of Enchant Gloves - Greater Strength
-,(38879, 1, 1) -- Scroll of Enchant Weapon - Strength
-,(38896, 1, 1) -- Scroll of Enchant 2H Weapon - Agility
-,(38880, 1, 1) -- Scroll of Enchant Weapon - Agility
-,(38881, 1, 1) -- Scroll of Enchant Bracer - Mana Regeneration
-,(38867, 1, 1) -- Scroll of Enchant Chest - Major Mana
-,(38868, 1, 1) -- Scroll of Enchant Weapon - Icy Chill
-,(38859, 1, 1) -- Scroll of Enchant Cloak - Superior Defense
-,(38860, 1, 1) -- Scroll of Enchant Shield - Vitality
 ,(20749, 1, 1) -- Brilliant Wizard Oil
-,(38866, 1, 1) -- Scroll of Enchant Chest - Major Health
-,(38864, 1, 1) -- Scroll of Enchant Boots - Spirit
 ,(20748, 1, 1) -- Brilliant Mana Oil
-,(38856, 1, 1) -- Scroll of Enchant Gloves - Greater Agility
-,(38853, 1, 1) -- Scroll of Enchant Bracer - Superior Spirit
-,(38838, 1, 1) -- Scroll of Enchant Weapon - Fiery Weapon
-,(38858, 1, 1) -- Scroll of Enchant Cloak - Greater Resistance
-,(38861, 1, 1) -- Scroll of Enchant Shield - Greater Stamina
-,(38862, 1, 1) -- Scroll of Enchant Boots - Greater Stamina
-,(38852, 1, 1) -- Scroll of Enchant Bracer - Greater Intellect
-,(38851, 1, 1) -- Scroll of Enchant Gloves - Minor Haste
 ,(20750, 1, 1) -- Wizard Oil
-,(38850, 1, 1) -- Scroll of Enchant Gloves - Riding Skill
 ,(20747, 1, 1) -- Lesser Mana Oil
-
-/* TODO (Priority order) */
 
 /* Tailoring (No gear) */
 ,(24275, 1, 1) -- Silver Spellthread
@@ -952,8 +851,7 @@ VALUES
 INSERT INTO mod_auctionhousebot_simpleitemconfig (itemID, numStacks, stackSize, sellPrice)
 VALUES
 
-/* Enchanting (40+) */
--- These items have no sell price, so one must be specified
+/* Enchanting: Mats with no sell price */
 (11176, 3, 0, 50) -- 40
 ,(11174, 3, 0, 150)
 ,(11175, 3, 0, 400)
@@ -974,12 +872,112 @@ VALUES
 -- ,(34054, 1) -- Northrend
 -- ,(34056, 3)
 
-/* Engineering */
--- These mounts should be super expensive. That's why they have a custom price.
+/* Enchanting: Scrolls (none have a sell price) (70-50) */
+,(22459, 1, 1, 50000) -- (1) Void Sphere
+,(38921, 1, 1, 150000) -- Scroll of Enchant Weapon - Major Spellpower
+,(38946, 1, 1, 150000) -- Scroll of Enchant Weapon - Major Healing
+,(22460, 1, 1, 10000) -- Prismatic Sphere
+,(38920, 1, 1, 150000) -- Scroll of Enchant Weapon - Potency
+,(38919, 1, 1, 150000) -- Scroll of Enchant 2H Weapon - Savagery
+,(38947, 1, 1, 150000) -- Scroll of Enchant Weapon - Greater Agility
+,(38884, 1, 1, 100000) -- Scroll of Enchant Weapon - Mighty Intellect
+,(38888, 1, 1, 100000) -- Scroll of Enchant Gloves - Fire Power
+,(38895, 1, 1, 100000) -- Scroll of Enchant Cloak - Dodge
+,(38891, 1, 1, 100000) -- Scroll of Enchant Cloak - Greater Fire Resistance
+,(50816, 1, 1, 100000) -- Scroll of Enchant Gloves - Angler
+,(38886, 1, 1, 100000) -- Scroll of Enchant Gloves - Shadow Power
+,(38894, 1, 1, 100000) -- Scroll of Enchant Cloak - Subtlety
+,(38936, 1, 1, 100000) -- Scroll of Enchant Gloves - Major Healing
+,(38890, 1, 1, 100000) -- Scroll of Enchant Gloves - Superior Agility
+,(38885, 1, 1, 100000) -- Scroll of Enchant Gloves - Threat
+,(38893, 1, 1, 100000) -- Scroll of Enchant Cloak - Stealth
+,(38942, 1, 1, 100000) -- Scroll of Enchant Cloak - Greater Shadow Resistance
+,(38889, 1, 1, 100000) -- Scroll of Enchant Gloves - Healing Power
+,(38892, 1, 1, 100000) -- Scroll of Enchant Cloak - Greater Nature Resistance
+,(38941, 1, 1, 100000) -- Scroll of Enchant Cloak - Greater Arcane Resistance
+,(38902, 1, 1, 100000) -- Scroll of Enchant Bracer - Fortitude
+,(38887, 1, 1, 100000) -- Scroll of Enchant Gloves - Frost Power
+,(38913, 1, 1, 100000) -- Scroll of Enchant Chest - Exceptional Stats
+,(38930, 1, 1, 100000) -- Scroll of Enchant Chest - Major Resilience
+,(38917, 1, 1, 150000) -- Scroll of Enchant Weapon - Major Striking
+,(38918, 1, 1, 150000) -- Scroll of Enchant Weapon - Major Intellect
+,(38906, 1, 1, 100000) -- Scroll of Enchant Shield - Shield Block
+,(37603, 1, 1, 100000) -- Scroll of Enchant Boots - Dexterity
+,(38933, 1, 1, 100000) -- Scroll of Enchant Gloves - Major Strength
+,(38901, 1, 1, 100000) -- Scroll of Enchant Bracer - Restore Mana Prime
+,(38883, 1, 1, 150000) -- Scroll of Enchant Weapon - Mighty Spirit
+,(38915, 1, 1, 100000) -- Scroll of Enchant Cloak - Major Resistance
+,(38949, 1, 1, 100000) -- Scroll of Enchant Shield - Resilience
+,(38945, 1, 1, 100000) -- Scroll of Enchant Shield - Major Stamina
+,(38939, 1, 1, 100000) -- Scroll of Enchant Cloak - Spell Penetration
+,(38900, 1, 1, 100000) -- Scroll of Enchant Bracer - Superior Healing
+,(38905, 1, 1, 100000) -- Scroll of Enchant Shield - Intellect
+,(38928, 1, 1, 100000) -- Scroll of Enchant Chest - Major Spirit
+,(38882, 1, 1, 100000) -- Scroll of Enchant Bracer - Healing Power
+,(38899, 1, 1, 100000) -- Scroll of Enchant Bracer - Major Defense
+,(38909, 1, 1, 100000) -- Scroll of Enchant Boots - Fortitude
+,(38898, 1, 1, 100000) -- Scroll of Enchant Bracer - Stats
+,(38911, 1, 1, 100000) -- Scroll of Enchant Chest - Exceptional Health
+,(38871, 1, 1, 150000) -- Scroll of Enchant Weapon - Lifestealing
+,(38874, 1, 1, 150000) -- Scroll of Enchant 2H Weapon - Major Spirit
+,(38904, 1, 1, 100000) -- Scroll of Enchant Shield - Tough Shield
+,(38940, 1, 1, 100000) -- Scroll of Enchant Cloak - Greater Agility
+
+,(38865, 1, 1, 100000) -- (51) Scroll of Enchant Chest - Greater Stats
+,(38934, 1, 1, 100000) -- Scroll of Enchant Gloves - Assault
+,(38914, 1, 1, 100000) -- Scroll of Enchant Cloak - Major Armor
+,(38873, 1, 1, 150000) -- Scroll of Enchant Weapon - Crusader
+,(38937, 1, 1, 100000) -- Scroll of Enchant Bracer - Major Intellect
+,(38908, 1, 1, 100000) -- Scroll of Enchant Boots - Vitality
+,(38931, 1, 1, 100000) -- Scroll of Enchant Gloves - Blasting
+,(38897, 1, 1, 100000) -- Scroll of Enchant Bracer - Brawn
+,(38875, 1, 1, 150000) -- Scroll of Enchant 2H Weapon - Major Intellect
+,(38870, 1, 1, 150000) -- Scroll of Enchant Weapon - Superior Striking
+,(38878, 1, 1, 150000) -- Scroll of Enchant Weapon - Healing Power
+,(38877, 1, 1, 150000) -- Scroll of Enchant Weapon - Spellpower
+,(38855, 1, 1, 100000) -- Scroll of Enchant Bracer - Superior Stamina
+,(38929, 1, 1, 100000) -- Scroll of Enchant Chest - Restore Mana Prime
+,(38938, 1, 1, 100000) -- Scroll of Enchant Bracer - Assault
+,(38869, 1, 1, 150000) -- Scroll of Enchant 2H Weapon - Superior Impact
+,(38872, 1, 1, 150000) -- Scroll of Enchant Weapon - Unholy Weapon
+,(38863, 1, 1, 100000) -- Scroll of Enchant Boots - Greater Agility
+,(38854, 1, 1, 100000) -- Scroll of Enchant Bracer - Superior Strength
+,(38857, 1, 1, 100000) -- Scroll of Enchant Gloves - Greater Strength
+,(38879, 1, 1, 150000) -- Scroll of Enchant Weapon - Strength
+,(38896, 1, 1, 150000) -- Scroll of Enchant 2H Weapon - Agility
+,(38880, 1, 1, 150000) -- Scroll of Enchant Weapon - Agility
+,(38881, 1, 1, 100000) -- Scroll of Enchant Bracer - Mana Regeneration
+,(38867, 1, 1, 100000) -- Scroll of Enchant Chest - Major Mana
+,(38868, 1, 1, 150000) -- Scroll of Enchant Weapon - Icy Chill
+,(38859, 1, 1, 100000) -- Scroll of Enchant Cloak - Superior Defense
+,(38860, 1, 1, 100000) -- Scroll of Enchant Shield - Vitality
+,(38866, 1, 1, 100000) -- Scroll of Enchant Chest - Major Health
+,(38864, 1, 1, 100000) -- Scroll of Enchant Boots - Spirit
+,(38856, 1, 1, 100000) -- Scroll of Enchant Gloves - Greater Agility
+,(38853, 1, 1, 100000) -- Scroll of Enchant Bracer - Superior Spirit
+,(38838, 1, 1, 150000) -- Scroll of Enchant Weapon - Fiery Weapon
+,(38858, 1, 1, 100000) -- Scroll of Enchant Cloak - Greater Resistance
+,(38861, 1, 1, 100000) -- Scroll of Enchant Shield - Greater Stamina
+,(38862, 1, 1, 100000) -- Scroll of Enchant Boots - Greater Stamina
+,(38852, 1, 1, 100000) -- Scroll of Enchant Bracer - Greater Intellect
+,(38851, 1, 1, 100000) -- Scroll of Enchant Gloves - Minor Haste
+,(38850, 1, 1, 100000) -- Scroll of Enchant Gloves - Riding Skill
+
+/* Inscription: Items with no sell price */
+,(43146, 1, 0, 5000) -- Weapon Vellum III
+,(43145, 1, 0, 1000) -- Armor Vellum III
+,(37602, 1, 0, 100) -- Armor Vellum II
+,(39350, 1, 0, 5000) -- Weapon Vellum II
+,(38682, 1, 0, 1000) -- Armor Vellum
+,(39349, 1, 0, 100) -- Weapon Vellum
+
+-- ,(44317, 1, 0) -- Greater Darkmoon Card -- Not obtainable without crafting
+
+/* Engineering: Mounts that should be super expensive + need a custom price */
 ,(41508, 1, 0, 50000000) -- Mechano-hog
 ,(44413, 1, 0, 50000000) -- Mekgineer's Chopper
 
--- These items have no sell price
+/* Engineering: Items with no sell price */
 ,(21569, 1, 1, 1000) -- Firework Launcher
 ,(21570, 1, 1, 2000) -- Cluster Launcher
 

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -2,8 +2,12 @@ TRUNCATE TABLE mod_auctionhousebot_simpleitemconfig;
 INSERT INTO mod_auctionhousebot_simpleitemconfig (itemID, numStacks, stackSize)
 VALUES
 
+/* Commonly sold drops */
+(30183, 3, 0) -- Nether Vortex
+,(33470, 3, 0) -- Frostweave Cloth
+
 /* Herbalism Trade Goods (60+) */
-(22787, 3, 0) -- (65)
+,(22787, 3, 0) -- (65)
 ,(22788, 1, 0)
 ,(22790, 1, 0)
 ,(22791, 3, 0)
@@ -52,12 +56,34 @@ VALUES
 ,(23439, 1, 0)
 ,(23440, 1, 0)
 ,(23441, 1, 0)
-,(32227, 1, 0) -- 70 Purple gems. ENDAGME Raid drops. 
+,(32227, 1, 0) -- 70 Purple gems. ENDGAME Raid drops. 
 ,(32228, 1, 0)
 ,(32229, 1, 0)
 ,(32230, 1, 0)
 ,(32231, 1, 0)
 ,(32249, 1, 0)
+-- WOTLK GEMS RAW --
+-- Greens
+,(36917, 1, 0) -- Bloodstone
+,(36920, 1, 0) -- Sun Crystal
+,(36923, 1, 0) -- Chalcedony
+,(36926, 1, 0) -- Shadow Crystal
+,(36929, 1, 0) -- Huge Citrine
+,(36932, 1, 0) -- Dark Jade
+-- Blues
+,(36918, 1, 0) -- Scarlet Ruby
+,(36921, 1, 0) -- Autumn's Glow
+,(36924, 1, 0) -- Sky Sapphire
+,(36927, 1, 0) -- Twilight Opal
+,(36930, 1, 0) -- Monarch Topaz
+,(36933, 1, 0) -- Forest Emerald
+-- Purples
+,(36919, 1, 0) -- Cardinal Ruby
+,(36922, 1, 0) -- King's Amber
+,(36925, 1, 0) -- Majestic Zircon
+,(36928, 1, 0) -- Dreadstone
+,(36931, 1, 0) -- Ametrine
+,(36934, 1, 0) -- Eye of Zul
 
 /* Skinning (60+) | No leather scraps */
 ,(4234, 3, 0) -- Heavy Leather
@@ -906,8 +932,13 @@ VALUES
 ,(22448, 3, 0, 60000)
 ,(22449, 1, 0, 80000)
 ,(22450, 1, 0, 200000) -- Endgame (70)
--- ,(34054, 1) -- Northrend
--- ,(34056, 3)
+-- WOTLK ENCHANTING MATS --
+,(34054, 1, 0,  20000) -- Infinite Dust
+,(34056, 1, 0,  30000) -- Lesser Cosmic Essence
+,(34055, 1, 0,  60000) -- Greater Cosmic Essence
+,(34053, 1, 0,  60000) -- Small Dream Shard
+,(34052, 1, 0, 160000) -- Dream Shard
+,(34057, 1, 0, 400000) -- Abyss Crystal
 
 /* Enchanting: Scrolls (none have a sell price) (70-50) */
 ,(22459, 1, 1, 50000) -- (1) Void Sphere

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -430,6 +430,17 @@ VALUES
 ,(6373, 1, 0) -- Elixir of Firepower
 ,(3390, 1, 0) -- Elixir of Lesser Agility
 ,(6048, 1, 0) -- Shadow Protection Potion
+,(2840, 3, 0) -- Copper Bar
+,(2842, 1, 0) -- Silver Bar
+,(2841, 3, 0) -- Bronze Bar
+,(3859, 1, 0) -- Steel Bar
+,(3860, 3, 0) -- Mithril Bar
+,(12359, 3, 0) -- Thorium Bar
+,(23445, 1, 0) -- Fel Iron Bar
+,(23446, 1, 0) -- Adamantite Bar
+,(23448, 1, 0) -- Felsteel Bar
+,(36916, 3, 0) -- Cobalt Bar
+,(36913, 3, 0) -- Saronite Bar
 
 ,(3389, 1, 0) -- Elixir of Defense
 ,(6371, 1, 0) -- Fire Oil

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -4,12 +4,13 @@ VALUES
 
 /* Commonly sold drops */
 (30183, 3, 0) -- Nether Vortex
-,(33470, 3, 0) -- Frostweave Cloth
 ,(43102, 3, 1) -- Frozen Orb
 ,(2589, 3, 0) -- Linen Cloth
 ,(2592, 3, 0) -- Wool Cloth
-,(4338, 1, 0) -- Mageweave Cloth
-,(14047, 1, 0) -- Runecloth
+,(4306, 3, 0) -- Silk Cloth
+,(4338, 3, 0) -- Mageweave Cloth
+,(14047, 3, 0) -- Runecloth
+,(33470, 3, 0) -- Frostweave Cloth
 
 
 /* Herbalism: Gathered (0-80) */
@@ -243,10 +244,10 @@ VALUES
 ,(42542, 1, 0) -- Stoic Mammoth Hide
 
 /* Alchemy */
-,(46377, 1, 0) -- Flask of Endless Rage
-,(46379, 1, 0) -- Flask of Stoneblood
-,(46378, 1, 0) -- Flask of Pure Mojo
-,(46376, 1, 0) -- Flask of the Frost Wyrm
+,(46377, 1, 3) -- Flask of Endless Rage
+,(46379, 1, 3) -- Flask of Stoneblood
+,(46378, 1, 3) -- Flask of Pure Mojo
+,(46376, 1, 3) -- Flask of the Frost Wyrm
 
 ,(41334, 1, 0) -- Earthsiege Diamond
 ,(41266, 1, 0) -- Skyflare Diamond
@@ -254,34 +255,34 @@ VALUES
 ,(41163, 1, 0) -- Titanium Bar
 ,(40081, 1, 0) -- Potion of Nightmares
 ,(40215, 1, 0) -- Mighty Frost Protection Potion
-,(44331, 1, 0) -- Elixir of Lightning Speed
-,(40070, 1, 0) -- Spellpower Elixir
-,(40097, 1, 0) -- Elixir of Protection
-,(44327, 1, 0) -- Elixir of Deadly Strikes
+,(44331, 1, 3) -- Elixir of Lightning Speed
+,(40070, 1, 3) -- Spellpower Elixir
+,(40097, 1, 3) -- Elixir of Protection
+,(44327, 1, 3) -- Elixir of Deadly Strikes
 ,(40216, 1, 0) -- Mighty Nature Protection Potion
-,(40078, 1, 0) -- Elixir of Mighty Fortitude
-,(40109, 1, 0) -- Elixir of Mighty Mageblood
+,(40078, 1, 3) -- Elixir of Mighty Fortitude
+,(40109, 1, 3) -- Elixir of Mighty Mageblood
 ,(40213, 1, 0) -- Mighty Arcane Protection Potion
-,(44330, 1, 0) -- Elixir of Armor Piercing
-,(40068, 1, 0) -- Wrath Elixir
-,(40073, 1, 0) -- Elixir of Mighty Strength
-,(44325, 1, 0) -- Elixir of Accuracy
+,(44330, 1, 3) -- Elixir of Armor Piercing
+,(40068, 1, 3) -- Wrath Elixir
+,(40073, 1, 3) -- Elixir of Mighty Strength
+,(44325, 1, 3) -- Elixir of Accuracy
 ,(33448, 3, 0) -- Runic Mana Potion
 ,(40214, 1, 0) -- Mighty Fire Protection Potion
-,(44939, 1, 0) -- Lesser Flask of Resistance
-,(40076, 1, 0) -- Guru's Elixir
+,(44939, 1, 3) -- Lesser Flask of Resistance
+,(40076, 1, 3) -- Guru's Elixir
 ,(40212, 1, 0) -- Potion of Wild Magic
 ,(40093, 1, 0) -- Indestructible Potion
-,(44329, 1, 0) -- Elixir of Expertise
-,(39666, 1, 0) -- Elixir of Mighty Agility
+,(44329, 1, 3) -- Elixir of Expertise
+,(39666, 1, 3) -- Elixir of Mighty Agility
 ,(33447, 3, 0) -- Runic Healing Potion
 ,(40217, 1, 0) -- Mighty Shadow Protection Potion
-,(44332, 1, 0) -- Elixir of Mighty Thoughts
-,(40072, 1, 0) -- Elixir of Spirit
+,(44332, 1, 3) -- Elixir of Mighty Thoughts
+,(40072, 1, 3) -- Elixir of Spirit
 ,(40211, 1, 0) -- Potion of Speed
 ,(40087, 1, 0) -- Powerful Rejuvenation Potion
-,(44328, 1, 0) -- Elixir of Mighty Defense
-,(40079, 1, 0) -- Lesser Flask of Toughness
+,(44328, 1, 3) -- Elixir of Mighty Defense
+,(40079, 1, 3) -- Lesser Flask of Toughness
 
 ,(39671, 1, 0) -- Resurgent Healing Potion
 ,(44958, 1, 0) -- Ethereal Oil
@@ -291,36 +292,36 @@ VALUES
 ,(25867, 3, 0) -- Earthstorm Diamond
 
 ,(22841, 1, 0) -- Major Fire Protection Potion
-,(33208, 1, 0) -- Flask of Chromatic Wonder
-,(22854, 1, 0) -- Flask of Relentless Assault
+,(33208, 1, 3) -- Flask of Chromatic Wonder
+,(22854, 1, 3) -- Flask of Relentless Assault
 ,(32839, 1, 0) -- Cauldron of Major Arcane Protection
 ,(22845, 1, 0) -- Major Arcane Protection Potion
 ,(22836, 1, 0) -- Major Dreamless Sleep Potion
 ,(32851, 1, 0) -- Cauldron of Major Nature Protection
-,(22848, 1, 0) -- Elixir of Empowerment
+,(22848, 1, 3) -- Elixir of Empowerment
 ,(22839, 1, 0) -- Destruction Potion
-,(22853, 1, 0) -- Flask of Mighty Restoration
+,(22853, 1, 3) -- Flask of Mighty Restoration
 ,(22844, 1, 0) -- Major Nature Protection Potion
-,(22835, 1, 0) -- Elixir of Major Shadow Power
-,(22866, 1, 0) -- Flask of Pure Death
+,(22835, 1, 3) -- Elixir of Major Shadow Power
+,(22866, 1, 3) -- Flask of Pure Death
 ,(32850, 1, 0) -- Cauldron of Major Frost Protection
 ,(22847, 1, 0) -- Major Holy Protection Potion
 ,(22838, 1, 0) -- Haste Potion
-,(22851, 1, 0) -- Flask of Fortification
+,(22851, 1, 3) -- Flask of Fortification
 ,(22842, 1, 0) -- Major Frost Protection Potion
-,(22861, 1, 0) -- Flask of Blinding Light
+,(22861, 1, 3) -- Flask of Blinding Light
 ,(32849, 1, 0) -- Cauldron of Major Fire Protection
 ,(22846, 1, 0) -- Major Shadow Protection Potion
 ,(22837, 1, 0) -- Heroic Potion
-,(22840, 1, 0) -- Elixir of Major Mageblood
+,(22840, 1, 3) -- Elixir of Major Mageblood
 ,(32852, 1, 0) -- Cauldron of Major Shadow Protection
 ,(31676, 1, 0) -- Fel Regeneration Potion
-,(22834, 1, 0) -- Elixir of Major Defense
+,(22834, 1, 3) -- Elixir of Major Defense
 ,(22832, 1, 0) -- Super Mana Potion
-,(31679, 1, 0) -- Fel Strength Elixir
+,(31679, 1, 3) -- Fel Strength Elixir
 ,(22871, 1, 0) -- Shrouding Potion
-,(32068, 1, 0) -- Elixir of Ironskin
-,(22831, 1, 0) -- Elixir of Major Agility
+,(32068, 1, 3) -- Elixir of Ironskin
+,(22831, 1, 3) -- Elixir of Major Agility
 ,(23571, 1, 0) -- Primal Might
 ,(21884, 1, 0) -- Primal Fire
 ,(21886, 1, 0) -- Primal Life
@@ -329,43 +330,43 @@ VALUES
 ,(22452, 1, 0) -- Primal Earth
 ,(22456, 1, 0) -- Primal Shadow
 ,(21885, 1, 0) -- Primal Water
-,(22830, 1, 0) -- Elixir of the Searching Eye
+,(22830, 1, 3) -- Elixir of the Searching Eye
 
 ,(22829, 1, 0) -- Super Healing Potion
-,(22827, 1, 0) -- Elixir of Major Frost Power
-,(22833, 1, 0) -- Elixir of Major Firepower
-,(32067, 1, 0) -- Elixir of Draenic Wisdom
+,(22827, 1, 3) -- Elixir of Major Frost Power
+,(22833, 1, 3) -- Elixir of Major Firepower
+,(32067, 1, 3) -- Elixir of Draenic Wisdom
 ,(22828, 1, 0) -- Insane Strength Potion
-,(28104, 1, 0) -- Elixir of Mastery
-,(32063, 1, 0) -- Earthen Elixir
+,(28104, 1, 3) -- Elixir of Mastery
+,(32063, 1, 3) -- Earthen Elixir
 ,(22826, 1, 0) -- Sneaking Potion
 ,(28101, 1, 0) -- Unstable Mana Potion
-,(32062, 1, 0) -- Elixir of Major Fortitude
-,(22825, 1, 0) -- Elixir of Healing Power
-,(22824, 1, 0) -- Elixir of Major Strength
-,(22823, 1, 0) -- Elixir of Camouflage
+,(32062, 1, 3) -- Elixir of Major Fortitude
+,(22825, 1, 3) -- Elixir of Healing Power
+,(22824, 1, 3) -- Elixir of Major Strength
+,(22823, 1, 3) -- Elixir of Camouflage
 ,(13506, 1, 0) -- Potion of Petrification
-,(28102, 1, 0) -- Onslaught Elixir
-,(13512, 1, 0) -- Flask of Supreme Power
+,(28102, 1, 3) -- Onslaught Elixir
+,(13512, 1, 3) -- Flask of Supreme Power
 ,(20002, 1, 0) -- Greater Dreamless Sleep Potion
 ,(18253, 1, 0) -- Major Rejuvenation Potion
-,(13511, 1, 0) -- Flask of Distilled Wisdom
+,(13511, 1, 3) -- Flask of Distilled Wisdom
 ,(28100, 1, 0) -- Volatile Healing Potion
-,(13510, 1, 0) -- Flask of the Titans
-,(28103, 1, 0) -- Adept's Elixir
-,(13513, 1, 0) -- Flask of Chromatic Resistance
+,(13510, 1, 3) -- Flask of the Titans
+,(28103, 1, 3) -- Adept's Elixir
+,(13513, 1, 3) -- Flask of Chromatic Resistance
 ,(13444, 1, 0) -- Major Mana Potion
 ,(13458, 1, 0) -- Greater Nature Protection Potion
 ,(13460, 1, 0) -- Greater Holy Protection Potion
 ,(13456, 1, 0) -- Greater Frost Protection Potion
 ,(13459, 1, 0) -- Greater Shadow Protection Potion
 ,(13457, 1, 0) -- Greater Fire Protection Potion
-,(20004, 1, 0) -- Mighty Troll's Blood Elixir
+,(20004, 1, 3) -- Mighty Troll's Blood Elixir
 ,(13461, 1, 0) -- Greater Arcane Protection Potion
 ,(13462, 1, 0) -- Purification Potion
-,(13454, 1, 0) -- Greater Arcane Elixir
+,(13454, 1, 3) -- Greater Arcane Elixir
 ,(20008, 1, 0) -- Living Action Potion
-,(13452, 1, 0) -- Elixir of the Mongoose
+,(13452, 1, 3) -- Elixir of the Mongoose
 ,(13455, 1, 0) -- Greater Stoneshield Potion
 ,(12803, 1, 0) -- Living Essence
 ,(12808, 1, 0) -- Essence of Undeath
@@ -375,30 +376,30 @@ VALUES
 ,(7080, 1, 0) -- Essence of Water
 ,(13446, 1, 0) -- Major Healing Potion
 ,(3386, 1, 0) -- Potion of Curing
-,(13453, 1, 0) -- Elixir of Brute Force
-,(13447, 1, 0) -- Elixir of the Sages
-,(13445, 1, 0) -- Elixir of Superior Defense
+,(13453, 1, 3) -- Elixir of Brute Force
+,(13447, 1, 3) -- Elixir of the Sages
+,(13445, 1, 3) -- Elixir of Superior Defense
 ,(13443, 1, 0) -- Superior Mana Potion
 ,(13442, 1, 0) -- Mighty Rage Potion
 
 ,(6037, 1, 0) -- Truesilver Bar
-,(9224, 1, 0) -- Elixir of Demonslaying
+,(9224, 1, 3) -- Elixir of Demonslaying
 ,(13423, 1, 0) -- Stonescale Oil
 ,(3387, 1, 0) -- Limited Invulnerability Potion
-,(21546, 1, 0) -- Elixir of Greater Firepower
-,(9264, 1, 0) -- Elixir of Shadow Power
-,(20007, 1, 0) -- Mageblood Elixir
-,(9233, 1, 0) -- Elixir of Detect Demon
-,(8827, 1, 0) -- Elixir of Water Walking
-,(9197, 1, 0) -- Elixir of Dream Vision
-,(9187, 1, 0) -- Elixir of Greater Agility
+,(21546, 1, 3) -- Elixir of Greater Firepower
+,(9264, 1, 3) -- Elixir of Shadow Power
+,(20007, 1, 3) -- Mageblood Elixir
+,(9233, 1, 3) -- Elixir of Detect Demon
+,(8827, 1, 3) -- Elixir of Water Walking
+,(9197, 1, 3) -- Elixir of Dream Vision
+,(9187, 1, 3) -- Elixir of Greater Agility
 ,(9088, 1, 0) -- Gift of Arthas
-,(9206, 1, 0) -- Elixir of Giants
-,(9179, 1, 0) -- Elixir of Greater Intellect
-,(9155, 1, 0) -- Arcane Elixir
+,(9206, 1, 3) -- Elixir of Giants
+,(9179, 1, 3) -- Elixir of Greater Intellect
+,(9155, 1, 3) -- Arcane Elixir
 ,(9172, 1, 0) -- Invisibility Potion
-,(9154, 1, 0) -- Elixir of Detect Undead
-,(18294, 1, 0) -- Elixir of Greater Water Breathing
+,(9154, 1, 3) -- Elixir of Detect Undead
+,(18294, 1, 3) -- Elixir of Greater Water Breathing
 ,(3928, 1, 0) -- Superior Healing Potion
 ,(12190, 1, 0) -- Dreamless Sleep Potion
 ,(9144, 1, 0) -- Wildvine Potion
@@ -409,15 +410,15 @@ VALUES
 ,(6149, 1, 0) -- Greater Mana Potion
 ,(8956, 1, 0) -- Oil of Immolation
 ,(3829, 1, 0) -- Frost Oil
-,(10592, 1, 0) -- Catseye Elixir
-,(3828, 1, 0) -- Elixir of Detect Lesser Invisibility
-,(8951, 1, 0) -- Elixir of Greater Defense
+,(10592, 1, 3) -- Catseye Elixir
+,(3828, 1, 3) -- Elixir of Detect Lesser Invisibility
+,(8951, 1, 3) -- Elixir of Greater Defense
 ,(6050, 1, 0) -- Frost Protection Potion
-,(17708, 1, 0) -- Elixir of Frost Power
+,(17708, 1, 3) -- Elixir of Frost Power
 ,(6052, 1, 0) -- Nature Protection Potion
-,(8949, 1, 0) -- Elixir of Agility
-,(3826, 1, 0) -- Major Troll's Blood Elixir
-,(3825, 1, 0) -- Elixir of Fortitude
+,(8949, 1, 3) -- Elixir of Agility
+,(3826, 1, 3) -- Major Troll's Blood Elixir
+,(3825, 1, 3) -- Elixir of Fortitude
 ,(5633, 1, 0) -- Great Rage Potion
 ,(3824, 1, 0) -- Shadow Oil
 ,(3823, 1, 0) -- Lesser Invisibility Potion
@@ -425,10 +426,10 @@ VALUES
 ,(3827, 1, 0) -- Mana Potion
 ,(1710, 1, 0) -- Greater Healing Potion
 ,(3577, 1, 0) -- Gold Bar
-,(3391, 1, 0) -- Elixir of Ogre's Strength
+,(3391, 1, 3) -- Elixir of Ogre's Strength
 ,(5634, 1, 0) -- Free Action Potion
-,(6373, 1, 0) -- Elixir of Firepower
-,(3390, 1, 0) -- Elixir of Lesser Agility
+,(6373, 1, 3) -- Elixir of Firepower
+,(3390, 1, 3) -- Elixir of Lesser Agility
 ,(6048, 1, 0) -- Shadow Protection Potion
 ,(2840, 3, 0) -- Copper Bar
 ,(2842, 1, 0) -- Silver Bar
@@ -442,20 +443,20 @@ VALUES
 ,(36916, 3, 0) -- Cobalt Bar
 ,(36913, 3, 0) -- Saronite Bar
 
-,(3389, 1, 0) -- Elixir of Defense
+,(3389, 1, 3) -- Elixir of Defense
 ,(6371, 1, 0) -- Fire Oil
 ,(7068, 1, 0) -- Elemental Fire
-,(3388, 1, 0) -- Strong Troll's Blood Elixir
+,(3388, 1, 3) -- Strong Troll's Blood Elixir
 ,(3385, 1, 0) -- Lesser Mana Potion
 ,(929, 1, 0) -- Healing Potion
 ,(3384, 1, 0) -- Minor Magic Resistance Potion
-,(3383, 1, 0) -- Elixir of Wisdom
+,(3383, 1, 3) -- Elixir of Wisdom
 ,(6051, 1, 0) -- Holy Protection Potion
-,(45621, 1, 0) -- Elixir of Minor Accuracy
+,(45621, 1, 3) -- Elixir of Minor Accuracy
 ,(6372, 1, 0) -- Swim Speed Potion
-,(6662, 1, 0) -- Elixir of Giant Growth
-,(5996, 1, 0) -- Elixir of Water Breathing
-,(2460, 1, 0) -- Elixir of Tongues (NYI)
+,(6662, 1, 3) -- Elixir of Giant Growth
+,(5996, 1, 3) -- Elixir of Water Breathing
+,(2460, 1, 3) -- Elixir of Tongues (NYI)
 ,(2456, 1, 0) -- Minor Rejuvenation Potion
 ,(2459, 1, 0) -- Swiftness Potion
 ,(2455, 1, 0) -- Minor Mana Potion
@@ -463,13 +464,14 @@ VALUES
 ,(4596, 1, 0) -- Discolored Healing Potion
 ,(5631, 1, 0) -- Rage Potion
 ,(858, 1, 0) -- Lesser Healing Potion
-,(2458, 1, 0) -- Elixir of Minor Fortitude
-,(2457, 1, 0) -- Elixir of Minor Agility
-,(3382, 1, 0) -- Weak Troll's Blood Elixir
-,(2454, 1, 0) -- Elixir of Lion's Strength
+,(2458, 1, 3) -- Elixir of Minor Fortitude
+,(2457, 1, 3) -- Elixir of Minor Agility
+,(3382, 1, 3) -- Weak Troll's Blood Elixir
+,(2454, 1, 3) -- Elixir of Lion's Strength
 ,(118, 1, 0) -- Minor Healing Potion
-,(5997, 1, 0) -- Elixir of Minor Defense
+,(5997, 1, 3) -- Elixir of Minor Defense
 ,(19931, 1, 0) -- Gurubashi Mojo Madness
+
 /* Jewelcrafting: Gems (Blue) */
 ,(40119, 1, 0) -- Solid Majestic Zircon
 ,(40120, 1, 0) -- Sparkling Majestic Zircon

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -60,6 +60,10 @@ VALUES
 ,(32249, 1, 0)
 
 /* Skinning (60+) | No leather scraps */
+,(4234, 3, 0) -- Heavy Leather
+,(4304, 3, 0) -- Thick Leather
+,(8170, 3, 0) -- Rugged Leather
+
 ,(29548, 1, 0) -- (60)
 ,(29547, 1, 0)
 ,(29539, 1, 0)

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -1,0 +1,986 @@
+TRUNCATE TABLE mod_auctionhousebot_simpleitemconfig;
+INSERT INTO mod_auctionhousebot_simpleitemconfig (itemID, numStacks, stackSize)
+VALUES
+
+/* Herbalism Trade Goods (60+) */
+(22787, 3, 0) -- (65)
+,(22788, 1, 0)
+,(22790, 1, 0)
+,(22791, 3, 0)
+,(22792, 3, 0)
+,(22793, 3, 0)
+,(22794, 1, 0) -- (70)
+
+/* Herbalism Everything else (60+) */
+,(19726, 1, 0) -- (60)
+,(13468, 1, 0)
+,(22575, 1, 0)
+,(22576, 1, 0)
+
+/* Enchanting (50+) */
+-- Enchanting is in a separate query as all items need sell prices
+
+/* Mining: Trade Goods (Ores, Stone, Elements) (50+) */
+,(11370, 1, 0) -- (50)
+,(7076, 1, 0) -- Kinda annoying to get
+,(23424, 3, 0)
+,(23425, 3, 0)
+,(22573, 2, 0)
+,(22574, 1, 0)
+,(23426, 1, 0)
+,(23427, 1, 0) -- (70)
+
+/* Mining: Non Trade Goods (Gems + a few other things) (50+) */
+,(7910, 3, 0) -- (50)
+,(11382, 3, 0)
+,(19774, 3, 0)
+,(12799, 3, 0)
+,(12361, 3, 0)
+,(12800, 3, 0)
+,(12363, 3, 0)
+,(12364, 3, 0) -- (60)
+,(23112, 2, 0)
+,(23117, 2, 0)
+,(23077, 2, 0)
+,(23079, 2, 0)
+,(21929, 2, 0)
+,(23107, 2, 0)
+-- ,(32464, 2, 0) -- (70) -- Quest item only
+,(23436, 1, 0)  -- 70 blue gems
+,(23437, 1, 0)
+,(23438, 1, 0)
+,(23439, 1, 0)
+,(23440, 1, 0)
+,(23441, 1, 0)
+,(32227, 1, 0) -- 70 Purple gems. ENDAGME Raid drops. 
+,(32228, 1, 0)
+,(32229, 1, 0)
+,(32230, 1, 0)
+,(32231, 1, 0)
+,(32249, 1, 0)
+
+/* Skinning (60+) | No leather scraps */
+,(29548, 1, 0) -- (60)
+,(29547, 1, 0)
+,(29539, 1, 0)
+,(25708, 1, 0)
+,(25700, 1, 0)
+,(25699, 1, 0)
+,(21887, 3, 0) -- Primary trade good
+,(19768, 1, 0)
+,(19767, 1, 0)
+,(17012, 1, 0)
+,(15414, 1, 0)
+,(15410, 1, 0)
+,(22578, 2, 0)
+,(22577, 2, 0)
+-- ,(22576, 2, 0) Excluded: Included in Herbalism section instead
+,(22572, 2, 0)
+,(25707, 1, 0) -- (70)
+
+-- ,(39686, 1, 0) -- Northrend
+-- ,(39682, 1, 0)
+-- ,(38558, 1, 0)
+
+/* Alchemy */
+,(25868, 3, 0) -- (1) Skyfire Diamond
+,(25867, 3, 0) -- Earthstorm Diamond
+,(22841, 3, 0) -- Major Fire Protection Potion
+,(22866, 1, 3) -- Flask of Pure Death
+,(32852, 3, 1) -- Cauldron of Major Shadow Protection
+,(22845, 3, 0) -- Major Arcane Protection Potion
+,(22836, 3, 0) -- Major Dreamless Sleep Potion
+,(22851, 1, 3) -- Flask of Fortification
+,(32839, 3, 1) -- Cauldron of Major Arcane Protection
+,(22848, 1, 3) -- Elixir of Empowerment
+,(22839, 3, 0) -- Destruction Potion
+,(22861, 1, 3) -- Flask of Blinding Light
+,(32851, 3, 1) -- Cauldron of Major Nature Protection
+,(22844, 3, 0) -- Major Nature Protection Potion
+,(22835, 1, 3) -- Elixir of Major Shadow Power
+,(22847, 3, 0) -- Major Holy Protection Potion
+,(22838, 3, 0) -- Haste Potion
+,(22854, 1, 3) -- Flask of Relentless Assault
+,(32850, 3, 1) -- Cauldron of Major Frost Protection
+,(22842, 3, 0) -- Major Frost Protection Potion
+,(33208, 1, 3) -- Flask of Chromatic Wonder
+,(22846, 3, 0) -- Major Shadow Protection Potion
+,(22837, 3, 0) -- Heroic Potion
+,(22853, 1, 3) -- Flask of Mighty Restoration
+,(32849, 3, 1) -- Cauldron of Major Fire Protection
+,(22840, 1, 3) -- Elixir of Major Mageblood
+,(31676, 3, 0) -- Fel Regeneration Potion
+,(22834, 1, 3) -- Elixir of Major Defense
+,(22832, 3, 0) -- Super Mana Potion
+,(22871, 3, 0) -- Shrouding Potion
+,(31679, 1, 3) -- Fel Strength Elixir
+,(32068, 1, 3) -- Elixir of Ironskin
+,(22831, 1, 3) -- Elixir of Major Agility
+,(23571, 3, 0) -- Primal Might
+,(22456, 3, 0) -- Primal Shadow
+,(21884, 3, 0) -- Primal Fire
+,(22451, 3, 0) -- Primal Air
+,(21886, 3, 0) -- Primal Life
+,(22452, 3, 0) -- Primal Earth
+,(22457, 3, 0) -- Primal Mana
+,(21885, 3, 0) -- Primal Water
+,(22830, 1, 3) -- Elixir of the Searching Eye
+,(22829, 3, 0) -- Super Healing Potion
+,(22827, 1, 3) -- Elixir of Major Frost Power
+,(22833, 1, 3) -- Elixir of Major Firepower
+,(22828, 3, 0) -- Insane Strength Potion
+,(32067, 1, 3) -- Elixir of Draenic Wisdom
+,(32063, 1, 3) -- Earthen Elixir
+,(28104, 1, 3) -- Elixir of Mastery
+,(22826, 3, 0) -- Sneaking Potion
+
+,(28101, 3, 0) -- (51) Unstable Mana Potion
+,(22825, 1, 3) -- Elixir of Healing Power
+,(32062, 1, 3) -- Elixir of Major Fortitude
+,(22824, 1, 3) -- Elixir of Major Strength
+,(22823, 1, 3) -- Elixir of Camouflage
+,(13506, 3, 0) -- Potion of Petrification
+,(13512, 1, 3) -- Flask of Supreme Power
+,(20002, 3, 0) -- Greater Dreamless Sleep Potion
+,(18253, 3, 0) -- Major Rejuvenation Potion
+,(28103, 1, 3) -- Adept's Elixir
+,(13511, 1, 3) -- Flask of Distilled Wisdom
+,(28102, 1, 3) -- Onslaught Elixir
+,(13510, 1, 3) -- Flask of the Titans
+,(13513, 1, 3) -- Flask of Chromatic Resistance
+,(28100, 3, 0) -- Volatile Healing Potion
+,(13444, 3, 0) -- Major Mana Potion
+,(13458, 3, 0) -- Greater Nature Protection Potion
+,(13460, 3, 0) -- Greater Holy Protection Potion
+,(13456, 3, 0) -- Greater Frost Protection Potion
+,(13459, 3, 0) -- Greater Shadow Protection Potion
+,(13457, 3, 0) -- Greater Fire Protection Potion
+,(20004, 1, 3) -- Mighty Troll's Blood Elixir
+,(13461, 3, 0) -- Greater Arcane Protection Potion
+,(13462, 3, 0) -- Purification Potion
+,(13454, 1, 3) -- Greater Arcane Elixir
+,(20008, 3, 0) -- Living Action Potion
+,(13452, 1, 3) -- Elixir of the Mongoose
+,(13455, 3, 0) -- Greater Stoneshield Potion
+,(12803, 3, 0) -- Living Essence
+-- ,(7076, 3, 0) -- Essence of Earth -- Already included in 'mining' section
+,(12808, 3, 0) -- Essence of Undeath
+,(12360, 3, 0) -- Arcanite Bar
+,(7078, 3, 0) -- Essence of Fire
+,(7082, 3, 0) -- Essence of Air
+,(7080, 3, 0) -- Essence of Water
+,(13446, 3, 0) -- Major Healing Potion
+,(3386, 3, 0) -- Potion of Curing
+,(13453, 1, 3) -- Elixir of Brute Force
+,(13447, 1, 3) -- Elixir of the Sages
+,(13445, 1, 3) -- Elixir of Superior Defense
+,(13443, 3, 0) -- Superior Mana Potion
+,(13442, 3, 0) -- Mighty Rage Potion
+,(6037, 3, 0) -- Truesilver Bar
+,(9224, 1, 3) -- Elixir of Demonslaying
+,(21546, 1, 3) -- Elixir of Greater Firepower
+,(3387, 3, 0) -- Limited Invulnerability Potion
+,(13423, 3, 0) -- Stonescale Oil
+,(9264, 1, 3) -- Elixir of Shadow Power
+,(20007, 1, 3) -- Mageblood Elixir
+,(8827, 1, 3) -- Elixir of Water Walking
+
+,(9233, 1, 3) -- (101) Elixir of Detect Demon
+
+/* Jewelcrafting */
+-- Note: No purple gems included
+
+,(24029, 3, 0) -- (1) Teardrop Living Ruby
+,(24059, 3, 0) -- Potent Noble Topaz
+,(24039, 3, 0) -- Stormy Star of Elune
+,(24035, 3, 0) -- Sparkling Star of Elune
+,(24054, 3, 0) -- Sovereign Nightseye
+,(25901, 3, 0) -- Insightful Earthstorm Diamond
+,(31861, 3, 0) -- Great Dawnstone
+,(35503, 3, 0) -- Ember Skyfire Diamond
+,(24032, 3, 0) -- Subtle Living Ruby
+,(24062, 3, 0) -- Enduring Talasite
+,(31868, 3, 0) -- Wicked Noble Topaz
+,(24051, 3, 0) -- Rigid Dawnstone
+,(25896, 3, 0) -- Powerful Earthstorm Diamond
+,(35315, 3, 0) -- Quick Dawnstone
+,(24027, 3, 0) -- Bold Living Ruby
+,(24057, 3, 0) -- Royal Nightseye
+,(25894, 3, 0) -- Swift Skyfire Diamond
+,(31865, 3, 0) -- Infused Nightseye
+,(24037, 3, 0) -- Lustrous Star of Elune
+,(24067, 3, 0) -- Jagged Talasite
+,(24053, 3, 0) -- Mystic Dawnstone
+,(25899, 3, 0) -- Brutal Earthstorm Diamond
+,(35501, 3, 0) -- Eternal Earthstorm Diamond
+,(24031, 3, 0) -- Bright Living Ruby
+,(24061, 3, 0) -- Glinting Noble Topaz
+,(31867, 3, 0) -- Veiled Noble Topaz
+,(24048, 3, 0) -- Smooth Dawnstone
+,(34220, 3, 0) -- Chaotic Skyfire Diamond
+,(24056, 3, 0) -- Glowing Nightseye
+,(25893, 3, 0) -- Mystical Skyfire Diamond
+,(35945, 3, 0) -- Brilliant Glass
+,(24033, 3, 0) -- Solid Star of Elune
+,(24065, 3, 0) -- Dazzling Talasite
+,(32410, 3, 0) -- Thundering Skyfire Diamond
+,(24052, 3, 0) -- Thick Dawnstone
+,(25898, 3, 0) -- Tenacious Earthstorm Diamond
+,(35318, 3, 0) -- Forceful Talasite
+,(24030, 3, 0) -- Runed Living Ruby
+,(24060, 3, 0) -- Luminous Noble Topaz
+,(24047, 3, 0) -- Brilliant Dawnstone
+,(33782, 3, 0) -- Steady Talasite
+,(24055, 3, 0) -- Shifting Nightseye
+,(25890, 3, 0) -- Destructive Skyfire Diamond
+,(35707, 3, 0) -- Regal Nightseye
+,(24036, 3, 0) -- Flashing Living Ruby
+,(24066, 3, 0) -- Radiant Talasite
+,(32409, 3, 0) -- Relentless Earthstorm Diamond
+,(24050, 3, 0) -- Gleaming Dawnstone
+,(25897, 3, 0) -- Bracing Earthstorm Diamond
+,(35316, 3, 0) -- Reckless Noble Topaz
+
+,(24028, 3, 0) -- (51) Delicate Living Ruby
+,(24058, 3, 0) -- Inscribed Noble Topaz
+,(25895, 3, 0) -- Enigmatic Skyfire Diamond
+,(31863, 3, 0) -- Balanced Nightseye
+-- Northrend Gem ,(39911, 3, 0) -- Runed Bloodstone
+-- Northrend Gem ,(39944, 3, 0) -- Infused Shadow Crystal
+-- Northrend Gem ,(39960, 3, 0) -- Wicked Huge Citrine
+-- Northrend Gem ,(39984, 3, 0) -- Dazzling Dark Jade
+-- Northrend Gem ,(39915, 3, 0) -- Rigid Sun Crystal
+-- Northrend Gem ,(39949, 3, 0) -- Champion's Huge Citrine
+-- Northrend Gem ,(39967, 3, 0) -- Resolute Huge Citrine
+-- Northrend Gem ,(39992, 3, 0) -- Shattered Dark Jade
+-- Northrend Gem ,(39936, 3, 0) -- Glowing Shadow Crystal
+-- Northrend Gem ,(39946, 3, 0) -- Luminous Huge Citrine
+-- Northrend Gem ,(39979, 3, 0) -- Seer's Dark Jade
+-- Northrend Gem ,(39908, 3, 0) -- Flashing Bloodstone
+-- Northrend Gem ,(39933, 3, 0) -- Puissant Shadow Crystal
+-- Northrend Gem ,(39963, 3, 0) -- Stark Huge Citrine
+-- Northrend Gem ,(39988, 3, 0) -- Opaque Dark Jade
+-- Northrend Gem ,(39917, 3, 0) -- Mystic Sun Crystal
+-- Northrend Gem ,(39952, 3, 0) -- Deadly Huge Citrine
+-- Northrend Gem ,(39975, 3, 0) -- Vivid Dark Jade
+-- Northrend Gem ,(39927, 3, 0) -- Lustrous Chalcedony
+-- Northrend Gem ,(39900, 3, 0) -- Bold Bloodstone
+-- Northrend Gem ,(39945, 3, 0) -- Mysterious Shadow Crystal
+-- Northrend Gem ,(39958, 3, 0) -- Durable Huge Citrine
+-- Northrend Gem ,(39982, 3, 0) -- Turbid Dark Jade
+-- Northrend Gem ,(39914, 3, 0) -- Smooth Sun Crystal
+-- Northrend Gem ,(39948, 3, 0) -- Etched Huge Citrine
+-- Northrend Gem ,(39966, 3, 0) -- Accurate Huge Citrine
+-- Northrend Gem ,(39991, 3, 0) -- Tense Dark Jade
+-- Northrend Gem ,(39942, 3, 0) -- Tenuous Shadow Crystal
+-- Northrend Gem ,(39955, 3, 0) -- Deft Huge Citrine
+-- Northrend Gem ,(39978, 3, 0) -- Forceful Dark Jade
+-- Northrend Gem ,(42701, 3, 0) -- Enchanted Pearl
+-- Northrend Gem ,(39907, 3, 0) -- Subtle Bloodstone
+-- Northrend Gem ,(39939, 3, 0) -- Defender's Shadow Crystal
+-- Northrend Gem ,(39962, 3, 0) -- Empowered Huge Citrine
+-- Northrend Gem ,(39986, 3, 0) -- Lambent Dark Jade
+-- Northrend Gem ,(39918, 3, 0) -- Quick Sun Crystal
+-- Northrend Gem ,(39951, 3, 0) -- Fierce Huge Citrine
+-- Northrend Gem ,(39974, 3, 0) -- Jagged Dark Jade
+-- Northrend Gem ,(39920, 3, 0) -- Sparkling Chalcedony
+-- Northrend Gem ,(39943, 3, 0) -- Royal Shadow Crystal
+-- Northrend Gem ,(39957, 3, 0) -- Veiled Huge Citrine
+-- Northrend Gem ,(39981, 3, 0) -- Shining Dark Jade
+-- Northrend Gem ,(39912, 3, 0) -- Brilliant Sun Crystal
+-- Northrend Gem ,(39947, 3, 0) -- Inscribed Huge Citrine
+-- Northrend Gem ,(39965, 3, 0) -- Glimmering Huge Citrine
+-- Northrend Gem ,(39990, 3, 0) -- Radiant Dark Jade
+
+-- Northrend Gem ,(39935, 3, 0) -- (101) Shifting Shadow Crystal
+-- Northrend Gem ,(39954, 3, 0) -- Lucent Huge Citrine
+-- Northrend Gem ,(39977, 3, 0) -- Steady Dark Jade
+-- Northrend Gem ,(39910, 3, 0) -- Precise Bloodstone
+-- Northrend Gem ,(39906, 3, 0) -- Bright Bloodstone
+-- Northrend Gem ,(39938, 3, 0) -- Regal Shadow Crystal
+-- Northrend Gem ,(39961, 3, 0) -- Pristine Huge Citrine
+-- Northrend Gem ,(39985, 3, 0) -- Sundered Dark Jade
+-- Northrend Gem ,(39916, 3, 0) -- Thick Sun Crystal
+-- Northrend Gem ,(39950, 3, 0) -- Resplendent Huge Citrine
+-- Northrend Gem ,(39968, 3, 0) -- Timeless Dark Jade
+-- Northrend Gem ,(39919, 3, 0) -- Solid Chalcedony
+-- Northrend Gem ,(39941, 3, 0) -- Purified Shadow Crystal
+-- Northrend Gem ,(39956, 3, 0) -- Potent Huge Citrine
+-- Northrend Gem ,(39980, 3, 0) -- Misty Dark Jade
+-- Northrend Gem ,(39909, 3, 0) -- Fractured Bloodstone
+-- Northrend Gem ,(39940, 3, 0) -- Guardian's Shadow Crystal
+-- Northrend Gem ,(39964, 3, 0) -- Stalwart Huge Citrine
+-- Northrend Gem ,(39989, 3, 0) -- Energized Dark Jade
+-- Northrend Gem ,(39934, 3, 0) -- Sovereign Shadow Crystal
+-- Northrend Gem ,(39953, 3, 0) -- Glinting Huge Citrine
+-- Northrend Gem ,(39976, 3, 0) -- Enduring Dark Jade
+-- Northrend Gem ,(39932, 3, 0) -- Stormy Chalcedony
+-- Northrend Gem ,(39905, 3, 0) -- Delicate Bloodstone
+-- Northrend Gem ,(39937, 3, 0) -- Balanced Shadow Crystal
+-- Northrend Gem ,(39959, 3, 0) -- Reckless Huge Citrine
+-- Northrend Gem ,(39983, 3, 0) -- Intricate Dark Jade
+-- ,(21780, 3, 0) -- Blood Crown
+-- ,(21793, 3, 0) -- Arcanite Sword Pendant
+-- ,(21779, 3, 0) -- Band of Natural Fire
+-- ,(21792, 3, 0) -- Necklace of the Diamond Tower
+,(32836, 3, 0) -- Purified Shadow Pearl
+,(31079, 3, 0) -- Mercurial Adamantite
+,(23101, 3, 0) -- Potent Flame Spessarite
+,(28290, 3, 0) -- Smooth Golden Draenite
+,(31866, 3, 0) -- Veiled Flame Spessarite
+,(23110, 3, 0) -- Shifting Shadow Draenite
+,(23096, 3, 0) -- Runed Blood Garnet
+,(23119, 3, 0) -- Sparkling Azure Moonstone
+,(45054, 3, 0) -- Prismatic Black Diamond
+,(23105, 3, 0) -- Enduring Deep Peridot
+,(23114, 3, 0) -- Gleaming Golden Draenite
+,(23099, 3, 0) -- Luminous Flame Spessarite
+,(23109, 3, 0) -- Royal Shadow Draenite
+,(32833, 3, 0) -- Purified Jaggal Pearl
+,(23095, 3, 0) -- Bold Blood Garnet
+,(23118, 3, 0) -- Solid Azure Moonstone
+,(31860, 3, 0) -- Great Golden Draenite
+,(23104, 3, 0) -- Jagged Deep Peridot
+,(23113, 3, 0) -- Brilliant Golden Draenite
+
+,(23121, 3, 0) -- (151) Lustrous Azure Moonstone
+,(31864, 3, 0) -- Infused Shadow Draenite
+,(23098, 3, 0) -- Inscribed Flame Spessarite
+,(23108, 3, 0) -- Glowing Shadow Draenite
+,(23094, 3, 0) -- Teardrop Blood Garnet
+,(23116, 3, 0) -- Rigid Golden Draenite
+,(23103, 3, 0) -- Radiant Deep Peridot
+,(28595, 3, 0) -- Bright Blood Garnet
+,(31869, 3, 0) -- Wicked Flame Spessarite
+,(23111, 3, 0) -- Sovereign Shadow Draenite
+,(23097, 3, 0) -- Delicate Blood Garnet
+,(23120, 3, 0) -- Stormy Azure Moonstone
+,(31862, 3, 0) -- Balanced Shadow Draenite
+,(23106, 3, 0) -- Dazzling Deep Peridot
+,(23115, 3, 0) -- Thick Golden Draenite
+,(23100, 3, 0) -- Glinting Flame Spessarite
+
+/* Inscription: Glyphs (Req level 70-30) */
+,(41107, 1, 1) -- (1) Glyph of Avenging Wrath
+,(43392, 1, 1) -- Glyph of Curse of Exhaustion
+,(43419, 1, 1) -- Glyph of Intervene
+,(44920, 1, 1) -- Glyph of Blast Wave
+,(44922, 1, 1) -- Glyph of Typhoon
+,(44923, 1, 1) -- Glyph of Thunderstorm
+,(44928, 1, 1) -- Glyph of Focus
+,(42959, 1, 1) -- Glyph of Deadly Throw
+,(43394, 1, 1) -- Glyph of Souls
+,(49084, 1, 1) -- Glyph of Command
+,(42414, 1, 1) -- Glyph of Shadow Word: Death
+,(42751, 1, 1) -- Glyph of Molten Armor
+,(42914, 1, 1) -- Glyph of Steady Shot
+,(43374, 1, 1) -- Glyph of Shadowfiend
+,(40921, 1, 1) -- Glyph of Starfall
+,(44955, 1, 1) -- Glyph of Arcane Blast
+,(43400, 1, 1) -- Glyph of Enduring Victory
+,(40900, 1, 1) -- Glyph of Mangle
+,(41101, 1, 1) -- Glyph of Avenger's Shield
+,(41552, 1, 1) -- Glyph of Elemental Mastery
+,(42396, 1, 1) -- Glyph of Circle of Healing
+,(42459, 1, 1) -- Glyph of Felguard
+,(42472, 1, 1) -- Glyph of Unstable Affliction
+,(42754, 1, 1) -- Glyph of Water Elemental
+,(43533, 1, 1) -- Glyph of Anti-Magic Shell
+,(43534, 1, 1) -- Glyph of Heart Strike
+,(43535, 1, 1) -- Glyph of Blood Tap
+,(43536, 1, 1) -- Glyph of Bone Shield
+,(43537, 1, 1) -- Glyph of Chains of Ice
+,(43538, 1, 1) -- Glyph of Dark Command
+,(43539, 1, 1) -- Glyph of Death's Embrace
+,(43541, 1, 1) -- Glyph of Death Grip
+,(43542, 1, 1) -- Glyph of Death and Decay
+,(43543, 1, 1) -- Glyph of Frost Strike
+,(43544, 1, 1) -- Glyph of Horn of Winter
+,(43545, 1, 1) -- Glyph of Icebound Fortitude
+,(43546, 1, 1) -- Glyph of Icy Touch
+,(43547, 1, 1) -- Glyph of Obliterate
+,(43548, 1, 1) -- Glyph of Plague Strike
+,(43549, 1, 1) -- Glyph of the Ghoul
+,(43550, 1, 1) -- Glyph of Rune Strike
+,(43551, 1, 1) -- Glyph of Scourge Strike
+,(43552, 1, 1) -- Glyph of Strangulate
+,(43553, 1, 1) -- Glyph of Unbreakable Armor
+,(43554, 1, 1) -- Glyph of Vampiric Blood
+,(43671, 1, 1) -- Glyph of Corpse Explosion
+,(43672, 1, 1) -- Glyph of Pestilence
+,(43673, 1, 1) -- Glyph of Raise Dead
+,(43825, 1, 1) -- Glyph of Rune Tap
+,(43826, 1, 1) -- Glyph of Blood Strike
+
+,(43827, 1, 1) -- (51) Glyph of Death Strike
+,(43867, 1, 1) -- Glyph of Holy Wrath
+,(43868, 1, 1) -- Glyph of Seal of Righteousness
+,(43869, 1, 1) -- Glyph of Seal of Vengeance
+,(50045, 1, 1) -- Glyph of Eternal Water
+,(43415, 1, 1) -- Glyph of Devastate
+,(41097, 1, 1) -- Glyph of Hammer of Wrath
+,(42457, 1, 1) -- Glyph of Death Coil
+,(40906, 1, 1) -- Glyph of Swiftmend
+,(40908, 1, 1) -- Glyph of Innervate
+,(40920, 1, 1) -- Glyph of Hurricane
+,(41517, 1, 1) -- Glyph of Chain Heal
+,(41538, 1, 1) -- Glyph of Mana Tide Totem
+,(41539, 1, 1) -- Glyph of Stormstrike
+,(42403, 1, 1) -- Glyph of Lightwell
+,(42454, 1, 1) -- Glyph of Conflagrate
+,(42463, 1, 1) -- Glyph of Howl of Terror
+,(42736, 1, 1) -- Glyph of Arcane Power
+,(42902, 1, 1) -- Glyph of Bestial Wrath
+,(42915, 1, 1) -- Glyph of Trueshot Aura
+,(42916, 1, 1) -- Glyph of Volley
+,(42917, 1, 1) -- Glyph of Wyvern Sting
+,(42954, 1, 1) -- Glyph of Adrenaline Rush
+,(45601, 1, 1) -- Glyph of Berserk
+,(45602, 1, 1) -- Glyph of Wild Growth
+,(45622, 1, 1) -- Glyph of Monsoon
+,(45623, 1, 1) -- Glyph of Barkskin
+,(45625, 1, 1) -- Glyph of Chimera Shot
+,(45731, 1, 1) -- Glyph of Explosive Shot
+,(45733, 1, 1) -- Glyph of Explosive Trap
+,(45734, 1, 1) -- Glyph of Scatter Shot
+,(45735, 1, 1) -- Glyph of Raptor Strike
+,(45736, 1, 1) -- Glyph of Deep Freeze
+,(45737, 1, 1) -- Glyph of Living Bomb
+,(45738, 1, 1) -- Glyph of Arcane Barrage
+,(45740, 1, 1) -- Glyph of Ice Barrier
+,(45741, 1, 1) -- Glyph of Beacon of Light
+,(45742, 1, 1) -- Glyph of Hammer of the Righteous
+,(45743, 1, 1) -- Glyph of Divine Storm
+,(45746, 1, 1) -- Glyph of Holy Shock
+,(45747, 1, 1) -- Glyph of Salvation
+,(45753, 1, 1) -- Glyph of Dispersion
+,(45755, 1, 1) -- Glyph of Guardian Spirit
+,(45756, 1, 1) -- Glyph of Penance
+,(45758, 1, 1) -- Glyph of Hymn of Hope
+,(45760, 1, 1) -- Glyph of Pain Suppression
+,(45761, 1, 1) -- Glyph of Hunger for Blood
+,(45762, 1, 1) -- Glyph of Killing Spree
+,(45764, 1, 1) -- Glyph of Shadow Dance
+,(45768, 1, 1) -- Glyph of Mutilate
+
+,(45769, 1, 1) -- (101) Glyph of Cloak of Shadows
+,(45770, 1, 1) -- Glyph of Thunder
+,(45771, 1, 1) -- Glyph of Feral Spirit
+,(45772, 1, 1) -- Glyph of Riptide
+,(45775, 1, 1) -- Glyph of Earth Shield
+,(45776, 1, 1) -- Glyph of Totem of Wrath
+,(45778, 1, 1) -- Glyph of Stoneclaw Totem
+,(45779, 1, 1) -- Glyph of Haunt
+,(45780, 1, 1) -- Glyph of Metamorphosis
+,(45781, 1, 1) -- Glyph of Chaos Bolt
+,(45785, 1, 1) -- Glyph of Life Tap
+,(45789, 1, 1) -- Glyph of Soul Link
+,(45790, 1, 1) -- Glyph of Bladestorm
+,(45792, 1, 1) -- Glyph of Shockwave
+,(45793, 1, 1) -- Glyph of Vigilance
+,(45795, 1, 1) -- Glyph of Spell Reflection
+,(45797, 1, 1) -- Glyph of Shield Wall
+,(45799, 1, 1) -- Glyph of Dancing Rune Weapon
+,(45800, 1, 1) -- Glyph of Hungering Cold
+,(45803, 1, 1) -- Glyph of Unholy Blight
+,(45804, 1, 1) -- Glyph of Dark Death
+,(45805, 1, 1) -- Glyph of Disease
+,(45806, 1, 1) -- Glyph of Howling Blast
+,(41109, 1, 1) -- Glyph of Seal of Wisdom
+,(40896, 1, 1) -- Glyph of Frenzied Regeneration
+,(43355, 1, 1) -- Glyph of the Pack
+,(43378, 1, 1) -- Glyph of Safe Fall
+,(43412, 1, 1) -- Glyph of Bloodthirst
+,(43421, 1, 1) -- Glyph of Mortal Strike
+,(43425, 1, 1) -- Glyph of Blocking
+,(42749, 1, 1) -- Glyph of Mage Armor
+,(41518, 1, 1) -- Glyph of Chain Lightning
+,(43432, 1, 1) -- Glyph of Whirlwind
+,(41104, 1, 1) -- Glyph of Cleansing
+,(41110, 1, 1) -- Glyph of Seal of Light
+,(41527, 1, 1) -- Glyph of Earthliving Weapon
+,(41542, 1, 1) -- Glyph of Windfury Weapon
+,(42405, 1, 1) -- Glyph of Mind Control
+,(42409, 1, 1) -- Glyph of Prayer of Healing
+,(42417, 1, 1) -- Glyph of Spirit of Redemption
+,(42460, 1, 1) -- Glyph of Felhunter
+,(42469, 1, 1) -- Glyph of Siphon Life
+,(42744, 1, 1) -- Glyph of Ice Block
+,(42750, 1, 1) -- Glyph of Mana Gem
+,(42899, 1, 1) -- Glyph of the Beast
+,(42957, 1, 1) -- Glyph of Blade Flurry
+,(42967, 1, 1) -- Glyph of Hemorrhage
+,(42968, 1, 1) -- Glyph of Preparation
+,(43351, 1, 1) -- Glyph of Feign Death
+,(43370, 1, 1) -- Glyph of Levitate
+
+,(42453, 1, 1) -- (151) Glyph of Incinerate
+,(42906, 1, 1) -- Glyph of Frost Trap
+,(43334, 1, 1) -- Glyph of Challenging Roar
+,(42471, 1, 1) -- Glyph of Succubus
+,(42911, 1, 1) -- Glyph of Rapid Fire
+,(43369, 1, 1) -- Glyph of the Wise
+,(43372, 1, 1) -- Glyph of Shadow Protection
+,(43381, 1, 1) -- Glyph of Astral Recall
+,(43385, 1, 1) -- Glyph of Renewed Life
+,(43393, 1, 1) -- Glyph of Enslave Demon
+,(43428, 1, 1) -- Glyph of Sweeping Strikes
+
+/* Inscription: Glyphs (Req level 29-0) */
+,(41102, 1, 1) -- (1) Glyph of Turn Evil
+,(40903, 1, 1) -- Glyph of Rake
+,(43388, 1, 1) -- Glyph of Water Walking
+,(40901, 1, 1) -- Glyph of Shred
+,(40902, 1, 1) -- Glyph of Rip
+,(40909, 1, 1) -- Glyph of Rebirth
+,(40916, 1, 1) -- Glyph of Starfire
+,(40919, 1, 1) -- Glyph of Insect Swarm
+,(41094, 1, 1) -- Glyph of Seal of Command
+,(41098, 1, 1) -- Glyph of Crusader Strike
+,(41099, 1, 1) -- Glyph of Consecration
+,(41103, 1, 1) -- Glyph of Exorcism
+,(41105, 1, 1) -- Glyph of Flash of Light
+,(41533, 1, 1) -- Glyph of Healing Stream Totem
+,(41535, 1, 1) -- Glyph of Lesser Healing Wave
+,(41541, 1, 1) -- Glyph of Water Mastery
+,(41547, 1, 1) -- Glyph of Frost Shock
+,(42399, 1, 1) -- Glyph of Fear Ward
+,(42400, 1, 1) -- Glyph of Flash Heal
+,(42401, 1, 1) -- Glyph of Holy Nova
+,(42407, 1, 1) -- Glyph of Shadow
+,(42412, 1, 1) -- Glyph of Scourge Imprisonment
+,(42468, 1, 1) -- Glyph of Shadowburn
+,(42737, 1, 1) -- Glyph of Blink
+,(42738, 1, 1) -- Glyph of Evocation
+,(42746, 1, 1) -- Glyph of Icy Veins
+,(42747, 1, 1) -- Glyph of Scorch
+,(42897, 1, 1) -- Glyph of Aimed Shot
+,(42903, 1, 1) -- Glyph of Deterrence
+,(42904, 1, 1) -- Glyph of Disengage
+,(42905, 1, 1) -- Glyph of Freezing Trap
+,(42958, 1, 1) -- Glyph of Crippling Poison
+,(42965, 1, 1) -- Glyph of Ghostly Strike
+,(42969, 1, 1) -- Glyph of Rupture
+,(43331, 1, 1) -- Glyph of Unburdened Rebirth
+,(43416, 1, 1) -- Glyph of Execution
+,(42397, 1, 1) -- Glyph of Dispel Magic
+,(42466, 1, 1) -- Glyph of Searing Pain
+,(42470, 1, 1) -- Glyph of Soulstone
+,(42753, 1, 1) -- Glyph of Remove Curse
+,(42910, 1, 1) -- Glyph of Multi-Shot
+,(42955, 1, 1) -- Glyph of Ambush
+,(43344, 1, 1) -- Glyph of Water Breathing
+,(43360, 1, 1) -- Glyph of Frost Ward
+,(43376, 1, 1) -- Glyph of Distract
+,(43380, 1, 1) -- Glyph of Vanish
+,(43391, 1, 1) -- Glyph of Kilrogg
+,(42908, 1, 1) -- Glyph of Immolation Trap
+,(42963, 1, 1) -- Glyph of Feint
+,(43316, 1, 1) -- Glyph of Aquatic Form
+
+,(43674, 1, 1) -- (51) Glyph of Dash
+,(42415, 1, 1) -- Glyph of Mind Flay
+,(42901, 1, 1) -- Glyph of Aspect of the Viper
+,(43357, 1, 1) -- Glyph of Fire Ward
+,(43365, 1, 1) -- Glyph of Blessing of Kings
+,(43368, 1, 1) -- Glyph of Sense Undead
+,(43373, 1, 1) -- Glyph of Shackle Undead
+,(43386, 1, 1) -- Glyph of Water Shield
+,(43414, 1, 1) -- Glyph of Cleaving
+,(43426, 1, 1) -- Glyph of Last Stand
+,(46372, 1, 1) -- Glyph of Survival Instincts
+,(48720, 1, 1) -- Glyph of Claw
+,(41100, 1, 1) -- Glyph of Righteous Defense
+,(42410, 1, 1) -- Glyph of Psychic Scream
+,(42734, 1, 1) -- Glyph of Arcane Explosion
+,(42962, 1, 1) -- Glyph of Expose Armor
+,(42964, 1, 1) -- Glyph of Garrote
+,(40912, 1, 1) -- Glyph of Regrowth
+,(41096, 1, 1) -- Glyph of Spiritual Attunement
+,(41530, 1, 1) -- Glyph of Fire Nova
+,(42402, 1, 1) -- Glyph of Inner Fire
+,(42461, 1, 1) -- Glyph of Health Funnel
+,(43377, 1, 1) -- Glyph of Pick Lock
+,(43398, 1, 1) -- Glyph of Mocking Blow
+,(43420, 1, 1) -- Glyph of Barbaric Insults
+,(43725, 1, 1) -- Glyph of Ghost Wolf
+,(40899, 1, 1) -- Glyph of Growl
+,(40923, 1, 1) -- Glyph of Moonfire
+,(41108, 1, 1) -- Glyph of Divinity
+,(41531, 1, 1) -- Glyph of Flame Shock
+,(41532, 1, 1) -- Glyph of Flametongue Weapon
+,(41540, 1, 1) -- Glyph of Lava Lash
+,(42406, 1, 1) -- Glyph of Shadow Word: Pain
+,(42455, 1, 1) -- Glyph of Corruption
+,(42462, 1, 1) -- Glyph of Healthstone
+,(42473, 1, 1) -- Glyph of Voidwalker
+,(42741, 1, 1) -- Glyph of Frost Nova
+,(42743, 1, 1) -- Glyph of Ice Armor
+,(42909, 1, 1) -- Glyph of the Hawk
+,(42970, 1, 1) -- Glyph of Sap
+,(42973, 1, 1) -- Glyph of Slice and Dice
+,(42974, 1, 1) -- Glyph of Sprint
+,(43338, 1, 1) -- Glyph of Revive Pet
+,(43431, 1, 1) -- Glyph of Victory Rush
+,(50077, 1, 1) -- Glyph of Quick Decay
+,(43354, 1, 1) -- Glyph of Possessed Strength
+,(43356, 1, 1) -- Glyph of Scare Beast
+,(43366, 1, 1) -- Glyph of Blessing of Wisdom
+,(43424, 1, 1) -- Glyph of Revenge
+,(41095, 1, 1) -- Glyph of Hammer of Justice
+
+,(41537, 1, 1) -- (101) Glyph of Lightning Shield
+,(42398, 1, 1) -- Glyph of Fade
+,(42411, 1, 1) -- Glyph of Renew
+,(42456, 1, 1) -- Glyph of Curse of Agony
+,(42458, 1, 1) -- Glyph of Fear
+,(42735, 1, 1) -- Glyph of Arcane Missiles
+,(42752, 1, 1) -- Glyph of Polymorph
+,(42960, 1, 1) -- Glyph of Evasion
+,(43350, 1, 1) -- Glyph of Mend Pet
+,(43364, 1, 1) -- Glyph of Slow Fall
+,(43422, 1, 1) -- Glyph of Overpower
+,(42408, 1, 1) -- Glyph of Power Word: Shield
+,(42740, 1, 1) -- Glyph of Fire Blast
+,(42898, 1, 1) -- Glyph of Arcane Shot
+,(42907, 1, 1) -- Glyph of Hunter's Mark
+,(42966, 1, 1) -- Glyph of Gouge
+,(43332, 1, 1) -- Glyph of Thorns
+,(40897, 1, 1) -- Glyph of Maul
+,(40914, 1, 1) -- Glyph of Healing Touch
+,(40924, 1, 1) -- Glyph of Entangling Roots
+,(42465, 1, 1) -- Glyph of Imp
+,(43367, 1, 1) -- Glyph of Lay on Hands
+,(43379, 1, 1) -- Glyph of Blurred Speed
+,(43390, 1, 1) -- Glyph of Drain Soul
+,(43396, 1, 1) -- Glyph of Bloodrage
+,(43427, 1, 1) -- Glyph of Sunder Armor
+,(43429, 1, 1) -- Glyph of Taunt
+,(41092, 1, 1) -- Glyph of Judgement
+,(41526, 1, 1) -- Glyph of Shocking
+,(42742, 1, 1) -- Glyph of Frostbolt
+,(42900, 1, 1) -- Glyph of Mending
+,(42912, 1, 1) -- Glyph of Serpent Sting
+,(42956, 1, 1) -- Glyph of Backstab
+,(40913, 1, 1) -- Glyph of Rejuvenation
+,(43342, 1, 1) -- Glyph of Fading
+,(43361, 1, 1) -- Glyph of the Penguin
+,(43417, 1, 1) -- Glyph of Hamstring
+,(50125, 1, 1) -- Glyph of Rapid Rejuvenation
+,(40922, 1, 1) -- Glyph of Wrath
+,(41106, 1, 1) -- Glyph of Holy Light
+,(41534, 1, 1) -- Glyph of Healing Wave
+,(41536, 1, 1) -- Glyph of Lightning Bolt
+,(42416, 1, 1) -- Glyph of Smite
+,(42464, 1, 1) -- Glyph of Immolate
+,(42467, 1, 1) -- Glyph of Shadow Bolt
+,(42739, 1, 1) -- Glyph of Fireball
+,(42961, 1, 1) -- Glyph of Eviscerate
+,(42972, 1, 1) -- Glyph of Sinister Strike
+,(43399, 1, 1) -- Glyph of Thunder Clap
+,(43430, 1, 1) -- Glyph of Resonating Power
+
+,(43340, 1, 1) -- (151) Glyph of Blessing of Might
+,(43343, 1, 1) -- Glyph of Pick Pocket
+,(43397, 1, 1) -- Glyph of Charge
+,(43413, 1, 1) -- Glyph of Rapid Charge
+,(43423, 1, 1) -- Glyph of Rending
+,(43335, 1, 1) -- Glyph of the Wild
+,(43339, 1, 1) -- Glyph of Arcane Intellect
+,(43359, 1, 1) -- Glyph of Frost Armor
+,(43371, 1, 1) -- Glyph of Fortitude
+,(43389, 1, 1) -- Glyph of Unending Breath
+,(43395, 1, 1) -- Glyph of Battle
+,(43418, 1, 1) -- Glyph of Heroic Strike
+
+/* Inscription: Scrolls + Vellums + Darkmoon cards */
+,(37093, 1, 0) -- Scroll of Stamina VII
+,(37091, 1, 0) -- Scroll of Intellect VII
+,(43463, 1, 0) -- Scroll of Agility VII
+,(37097, 1, 0) -- Scroll of Spirit VII
+,(43465, 1, 0) -- Scroll of Strength VII
+
+,(43146, 1, 0) -- Weapon Vellum III
+,(43145, 1, 0) -- Armor Vellum III
+,(37602, 1, 0) -- Armor Vellum II
+,(39350, 1, 0) -- Weapon Vellum II
+,(38682, 1, 0) -- Armor Vellum
+,(39349, 1, 0) -- Weapon Vellum
+
+,(44317, 1, 0) -- Greater Darkmoon Card
+
+/* Enchanting: Used by other professions */
+,(12655, 1, 0) -- Enchanted Thorium Bar
+,(12810, 1, 0) -- Enchanted Leather
+
+/* Enchanting: Enchants (70-50) */
+,(22459, 1, 1) -- (1) Void Sphere
+,(38921, 1, 1) -- Scroll of Enchant Weapon - Major Spellpower
+,(38946, 1, 1) -- Scroll of Enchant Weapon - Major Healing
+,(22460, 1, 1) -- Prismatic Sphere
+,(38920, 1, 1) -- Scroll of Enchant Weapon - Potency
+,(38919, 1, 1) -- Scroll of Enchant 2H Weapon - Savagery
+,(38947, 1, 1) -- Scroll of Enchant Weapon - Greater Agility
+,(38884, 1, 1) -- Scroll of Enchant Weapon - Mighty Intellect
+,(38888, 1, 1) -- Scroll of Enchant Gloves - Fire Power
+,(38895, 1, 1) -- Scroll of Enchant Cloak - Dodge
+,(38891, 1, 1) -- Scroll of Enchant Cloak - Greater Fire Resistance
+,(50816, 1, 1) -- Scroll of Enchant Gloves - Angler
+,(38886, 1, 1) -- Scroll of Enchant Gloves - Shadow Power
+,(38894, 1, 1) -- Scroll of Enchant Cloak - Subtlety
+,(38936, 1, 1) -- Scroll of Enchant Gloves - Major Healing
+,(38890, 1, 1) -- Scroll of Enchant Gloves - Superior Agility
+,(38885, 1, 1) -- Scroll of Enchant Gloves - Threat
+,(38893, 1, 1) -- Scroll of Enchant Cloak - Stealth
+,(38942, 1, 1) -- Scroll of Enchant Cloak - Greater Shadow Resistance
+,(38889, 1, 1) -- Scroll of Enchant Gloves - Healing Power
+,(38892, 1, 1) -- Scroll of Enchant Cloak - Greater Nature Resistance
+,(38941, 1, 1) -- Scroll of Enchant Cloak - Greater Arcane Resistance
+,(38902, 1, 1) -- Scroll of Enchant Bracer - Fortitude
+,(38887, 1, 1) -- Scroll of Enchant Gloves - Frost Power
+,(38913, 1, 1) -- Scroll of Enchant Chest - Exceptional Stats
+,(38930, 1, 1) -- Scroll of Enchant Chest - Major Resilience
+,(38917, 1, 1) -- Scroll of Enchant Weapon - Major Striking
+,(38918, 1, 1) -- Scroll of Enchant Weapon - Major Intellect
+,(38906, 1, 1) -- Scroll of Enchant Shield - Shield Block
+,(22522, 1, 1) -- Superior Wizard Oil
+,(37603, 1, 1) -- Scroll of Enchant Boots - Dexterity
+,(38933, 1, 1) -- Scroll of Enchant Gloves - Major Strength
+,(38901, 1, 1) -- Scroll of Enchant Bracer - Restore Mana Prime
+,(38883, 1, 1) -- Scroll of Enchant Weapon - Mighty Spirit
+,(38915, 1, 1) -- Scroll of Enchant Cloak - Major Resistance
+,(38949, 1, 1) -- Scroll of Enchant Shield - Resilience
+,(38945, 1, 1) -- Scroll of Enchant Shield - Major Stamina
+,(38939, 1, 1) -- Scroll of Enchant Cloak - Spell Penetration
+,(38900, 1, 1) -- Scroll of Enchant Bracer - Superior Healing
+,(38905, 1, 1) -- Scroll of Enchant Shield - Intellect
+,(38928, 1, 1) -- Scroll of Enchant Chest - Major Spirit
+,(38882, 1, 1) -- Scroll of Enchant Bracer - Healing Power
+,(38899, 1, 1) -- Scroll of Enchant Bracer - Major Defense
+,(38909, 1, 1) -- Scroll of Enchant Boots - Fortitude
+,(38898, 1, 1) -- Scroll of Enchant Bracer - Stats
+,(38911, 1, 1) -- Scroll of Enchant Chest - Exceptional Health
+,(38871, 1, 1) -- Scroll of Enchant Weapon - Lifestealing
+,(38874, 1, 1) -- Scroll of Enchant 2H Weapon - Major Spirit
+,(38904, 1, 1) -- Scroll of Enchant Shield - Tough Shield
+,(38940, 1, 1) -- Scroll of Enchant Cloak - Greater Agility
+
+,(38865, 1, 1) -- (51) Scroll of Enchant Chest - Greater Stats
+,(38934, 1, 1) -- Scroll of Enchant Gloves - Assault
+,(38914, 1, 1) -- Scroll of Enchant Cloak - Major Armor
+,(22521, 1, 1) -- Superior Mana Oil
+,(38873, 1, 1) -- Scroll of Enchant Weapon - Crusader
+,(38937, 1, 1) -- Scroll of Enchant Bracer - Major Intellect
+,(38908, 1, 1) -- Scroll of Enchant Boots - Vitality
+,(38931, 1, 1) -- Scroll of Enchant Gloves - Blasting
+,(38897, 1, 1) -- Scroll of Enchant Bracer - Brawn
+,(38875, 1, 1) -- Scroll of Enchant 2H Weapon - Major Intellect
+,(38870, 1, 1) -- Scroll of Enchant Weapon - Superior Striking
+,(38878, 1, 1) -- Scroll of Enchant Weapon - Healing Power
+,(38877, 1, 1) -- Scroll of Enchant Weapon - Spellpower
+,(38855, 1, 1) -- Scroll of Enchant Bracer - Superior Stamina
+,(38929, 1, 1) -- Scroll of Enchant Chest - Restore Mana Prime
+,(38938, 1, 1) -- Scroll of Enchant Bracer - Assault
+,(38869, 1, 1) -- Scroll of Enchant 2H Weapon - Superior Impact
+,(38872, 1, 1) -- Scroll of Enchant Weapon - Unholy Weapon
+,(38863, 1, 1) -- Scroll of Enchant Boots - Greater Agility
+,(38854, 1, 1) -- Scroll of Enchant Bracer - Superior Strength
+,(38857, 1, 1) -- Scroll of Enchant Gloves - Greater Strength
+,(38879, 1, 1) -- Scroll of Enchant Weapon - Strength
+,(38896, 1, 1) -- Scroll of Enchant 2H Weapon - Agility
+,(38880, 1, 1) -- Scroll of Enchant Weapon - Agility
+,(38881, 1, 1) -- Scroll of Enchant Bracer - Mana Regeneration
+,(38867, 1, 1) -- Scroll of Enchant Chest - Major Mana
+,(38868, 1, 1) -- Scroll of Enchant Weapon - Icy Chill
+,(38859, 1, 1) -- Scroll of Enchant Cloak - Superior Defense
+,(38860, 1, 1) -- Scroll of Enchant Shield - Vitality
+,(20749, 1, 1) -- Brilliant Wizard Oil
+,(38866, 1, 1) -- Scroll of Enchant Chest - Major Health
+,(38864, 1, 1) -- Scroll of Enchant Boots - Spirit
+,(20748, 1, 1) -- Brilliant Mana Oil
+,(38856, 1, 1) -- Scroll of Enchant Gloves - Greater Agility
+,(38853, 1, 1) -- Scroll of Enchant Bracer - Superior Spirit
+,(38838, 1, 1) -- Scroll of Enchant Weapon - Fiery Weapon
+,(38858, 1, 1) -- Scroll of Enchant Cloak - Greater Resistance
+,(38861, 1, 1) -- Scroll of Enchant Shield - Greater Stamina
+,(38862, 1, 1) -- Scroll of Enchant Boots - Greater Stamina
+,(38852, 1, 1) -- Scroll of Enchant Bracer - Greater Intellect
+,(38851, 1, 1) -- Scroll of Enchant Gloves - Minor Haste
+,(20750, 1, 1) -- Wizard Oil
+,(38850, 1, 1) -- Scroll of Enchant Gloves - Riding Skill
+,(20747, 1, 1) -- Lesser Mana Oil
+
+/* TODO (Priority order) */
+
+/* Tailoring (No gear) */
+,(24275, 1, 1) -- Silver Spellthread
+,(24273, 1, 1) -- Mystic Spellthread
+
+,(21876, 1, 0) -- Primal Mooncloth Bag
+,(21843, 1, 0) -- Imbued Netherweave Bag
+,(22252, 1, 0) -- Satchel of Cenarius
+,(24270, 1, 0) -- Bag of Jewels
+,(22249, 1, 0) -- Big Bag of Enchantment
+,(21841, 1, 0) -- Netherweave Bag
+,(14156, 1, 0) -- Bottomless Bag
+,(21342, 1, 0) -- Core Felcloth Bag
+,(14155, 1, 0) -- Mooncloth Bag
+,(21341, 1, 0) -- Felcloth Bag
+,(22251, 1, 0) -- Cenarion Herb Bag
+,(22248, 1, 0) -- Enchanted Runecloth Bag
+,(21340, 1, 0) -- Soul Pouch
+,(14046, 1, 0) -- Runecloth Bag
+,(22246, 1, 0) -- Enchanted Mageweave Pouch
+,(10051, 1, 0) -- Red Mageweave Bag
+,(10050, 1, 0) -- Mageweave Bag
+,(5765, 1, 0) -- Black Silk Pack
+,(4245, 1, 0) -- Small Silk Pack
+,(5764, 1, 0) -- Green Silk Pack
+,(4241, 1, 0) -- Green Woolen Bag
+,(4240, 1, 0) -- Woolen Bag
+,(5763, 1, 0) -- Red Woolen Bag
+,(5762, 1, 0) -- Red Linen Bag
+,(4238, 1, 0) -- Linen Bag
+
+/* Leatherworking (No gear) */
+,(34207, 1, 1) -- Glove Reinforcements
+,(34330, 1, 1) -- Heavy Knothide Armor Kit
+,(29485, 1, 1) -- Flame Armor Kit
+,(29488, 1, 1) -- Arcane Armor Kit
+,(29483, 1, 1) -- Shadow Armor Kit
+,(29487, 1, 1) -- Nature Armor Kit
+,(29486, 1, 1) -- Frost Armor Kit
+,(29533, 1, 1) -- Cobrahide Leg Armor
+,(29534, 1, 1) -- Clefthide Leg Armor
+,(25652, 1, 1) -- Magister's Armor Kit
+,(25651, 1, 1) -- Vindicator's Armor Kit
+,(18251, 1, 1) -- Core Armor Kit
+,(25679, 1, 1) -- Comfortable Insoles
+,(25650, 1, 1) -- Knothide Armor Kit
+
+,(34490, 1, 0) -- Bag of Many Hides
+,(34106, 1, 0) -- Netherscale Ammo Pouch
+,(34105, 1, 0) -- Quiver of a Thousand Feathers
+,(34100, 1, 0) -- Knothide Quiver
+,(34099, 1, 0) -- Knothide Ammo Pouch
+,(34482, 1, 0) -- Leatherworker's Satchel
+,(29540, 1, 0) -- Reinforced Mining Bag
+,(8218, 1, 0) -- Thick Leather Ammo Pouch
+,(8217, 1, 0) -- Quickdraw Quiver
+,(7372, 1, 0) -- Heavy Leather Ammo Pouch
+,(7371, 1, 0) -- Heavy Quiver
+,(5081, 1, 0) -- Kodo Hide Bag
+,(7278, 1, 0) -- Light Leather Quiver
+,(7279, 1, 0) -- Small Leather Ammo Pouch
+
+/* Blacksmithing */
+,(41745, 1, 0) -- Titanium Rod
+,(25844, 1, 0) -- Adamantite Rod
+,(25843, 1, 0) -- Fel Iron Rod
+
+,(23530, 1, 1) -- Felsteel Shield Spike
+,(23529, 1, 1) -- Adamantite Sharpening Stone
+,(28421, 1, 1) -- Adamantite Weightstone
+,(23576, 1, 1) -- Greater Ward of Shielding
+,(25521, 1, 1) -- Greater Rune of Warding
+,(23575, 1, 1) -- Lesser Ward of Shielding
+,(23559, 1, 1) -- Lesser Rune of Warding
+,(33185, 1, 1) -- Adamantite Weapon Chain
+,(18262, 1, 1) -- Elemental Sharpening Stone
+,(23528, 1, 1) -- Fel Sharpening Stone
+,(28420, 1, 1) -- Fel Weightstone
+,(7969, 1, 1) -- Mithril Spurs
+
+/* Engineering: Useless junk? */
+,(20475, 1, 1) -- Adamantite Arrow Maker
+,(34504, 1, 1) -- Adamantite Shell Machine
+,(33093, 1, 0) -- Mana Potion Injector
+,(23764, 1, 1) -- Adamantite Scope
+,(33092, 1, 0) -- Healing Potion Injector
+,(23832, 1, 1) -- Gnomish Tonk Controller
+,(23831, 1, 1) -- Goblin Tonk Controller
+,(18283, 1, 1) -- Biznicks 247x128 Accurascope
+,(23767, 1, 1) -- Crashin' Thrashin' Robot
+,(21277, 1, 1) -- Tranquil Mechanical Yeti
+,(22728, 1, 1) -- Steam Tonk Controller
+,(15996, 1, 1) -- Lifelike Mechanical Toad
+,(19026, 1, 0) -- Snake Burst Firework
+,(10548, 1, 1) -- Sniper Scope
+,(10580, 1, 1) -- Goblin "Boom" Box
+,(11826, 1, 1) -- Lil' Smoky
+,(11825, 1, 1) -- Pet Bombling
+,(18588, 1, 0) -- Ez-Thro Dynamite II
+,(4852, 1, 0) -- Flash Bomb
+,(10498, 1, 1) -- Gyromatic Micro-Adjustor
+,(4388, 1, 1) -- Discombobulator Ray
+,(4386, 1, 1) -- Ice Deflector
+,(5507, 1, 1) -- Ornate Spyglass
+,(6714, 1, 0) -- Ez-Thro Dynamite
+,(4376, 1, 1) -- Flame Deflector
+,(4406, 1, 1) -- Standard Scope
+,(9312, 1, 0) -- Blue Firework
+,(9313, 1, 0) -- Green Firework
+,(6712, 1, 1) -- Practice Lock
+,(9318, 1, 0) -- Red Firework
+,(4401, 1, 1) -- Mechanical Squirrel Box
+,(4405, 1, 1) -- Crude Scope
+,(40892, 1, 1) -- Hammer Pick
+,(40893, 1, 1) -- Bladed Pickaxe
+,(21571, 1, 0) -- Blue Rocket Cluster
+,(23770, 1, 0) -- Blue Smoke Flare
+
+,(21574, 1, 0) -- Green Rocket Cluster
+,(23771, 1, 0) -- Green Smoke Flare
+,(21589, 1, 0) -- Large Blue Rocket
+,(21714, 1, 0) -- Large Blue Rocket Cluster
+,(21590, 1, 0) -- Large Green Rocket
+,(21716, 1, 0) -- Large Green Rocket Cluster
+,(21592, 1, 0) -- Large Red Rocket
+,(21718, 1, 0) -- Large Red Rocket Cluster
+,(25886, 1, 0) -- Purple Smoke Flare
+,(21576, 1, 0) -- Red Rocket Cluster
+,(23769, 1, 0) -- Red Smoke Flare
+,(21558, 1, 0) -- Small Blue Rocket
+
+,(21559, 1, 0) -- Small Green Rocket
+,(21557, 1, 0) -- Small Red Rocket
+,(23768, 1, 0) -- White Smoke Flare
+
+;
+
+/****** All items that have no vendor price + thus need an explicitly specified sell price ******/
+INSERT INTO mod_auctionhousebot_simpleitemconfig (itemID, numStacks, stackSize, sellPrice)
+VALUES
+
+/* Enchanting (40+) */
+-- These items have no sell price, so one must be specified
+(11176, 3, 0, 50) -- 40
+,(11174, 3, 0, 150)
+,(11175, 3, 0, 400)
+,(11177, 3, 0, 600)
+,(11178, 3, 0, 800)
+,(16204, 3, 0, 1000) -- 50 (Vanilla)
+,(16202, 3, 0, 1500)
+,(16203, 3, 0, 4000)
+,(14343, 3, 0, 6000)
+,(14344, 3, 0, 8000)
+,(20725, 1, 0, 20000)
+,(22445, 3, 0, 2000) -- TBC
+,(22447, 3, 0, 15000)
+,(22446, 3, 0, 40000)
+,(22448, 3, 0, 60000)
+,(22449, 1, 0, 80000)
+,(22450, 1, 0, 200000) -- Endgame (70)
+-- ,(34054, 1) -- Northrend
+-- ,(34056, 3)
+
+/* Engineering */
+-- These mounts should be super expensive. That's why they have a custom price.
+,(41508, 1, 0, 50000000) -- Mechano-hog
+,(44413, 1, 0, 50000000) -- Mekgineer's Chopper
+
+-- These items have no sell price
+,(21569, 1, 1, 1000) -- Firework Launcher
+,(21570, 1, 1, 2000) -- Cluster Launcher
+
+;

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -934,10 +934,10 @@ VALUES
 ,(22450, 1, 0, 200000) -- Endgame (70)
 -- WOTLK ENCHANTING MATS --
 ,(34054, 1, 0,  20000) -- Infinite Dust
-,(34056, 1, 0,  30000) -- Lesser Cosmic Essence
-,(34055, 1, 0,  60000) -- Greater Cosmic Essence
-,(34053, 1, 0,  60000) -- Small Dream Shard
-,(34052, 1, 0, 160000) -- Dream Shard
+,(34056, 1, 0,  40000) -- Lesser Cosmic Essence
+,(34055, 1, 0,  120000) -- Greater Cosmic Essence
+,(34053, 1, 0,  70000) -- Small Dream Shard
+,(34052, 1, 0, 210000) -- Dream Shard
 ,(34057, 1, 0, 400000) -- Abyss Crystal
 
 /* Enchanting: Scrolls (none have a sell price) (70-50) */

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -6,78 +6,157 @@ VALUES
 (30183, 3, 0) -- Nether Vortex
 ,(33470, 3, 0) -- Frostweave Cloth
 
-/* Herbalism Trade Goods (60+) */
-,(22787, 3, 0) -- (65)
-,(22788, 1, 0)
-,(22790, 1, 0)
-,(22791, 3, 0)
-,(22792, 3, 0)
-,(22793, 3, 0)
-,(22794, 1, 0) -- (70)
-
-/* Herbalism Everything else (60+) */
-,(19726, 1, 0) -- (60)
-,(13468, 1, 0)
-,(22575, 1, 0)
-,(22576, 1, 0)
+/* Herbalism: Gathered (0-80) */
+,(36908, 1, 0) -- Frost Lotus
+,(36906, 3, 0) -- Icethorn
+,(36905, 3, 0) -- Lichbloom
+,(36903, 3, 0) -- Adder's Tongue
+,(39970, 3, 0) -- Fire Leaf
+,(37704, 3, 0) -- Crystallized Life | Note: Not an herb but gathered primarily by herbalism
+,(39969, 3, 0) -- Fire Seed
+,(37921, 3, 0) -- Deadnettle
+,(36901, 3, 0) -- Goldclover
+,(36904, 3, 0) -- Tiger Lily
+,(36907, 3, 0) -- Talandra's Rose
+,(22794, 1, 0) -- Fel Lotus
+,(32506, 1, 0) -- Netherwing Egg
+,(22793, 1, 0) -- Mana Thistle
+,(32468, 1, 0) -- Netherdust Pollen
+,(22792, 1, 0) -- Nightmare Vine
+,(22791, 1, 0) -- Netherbloom
+,(22790, 1, 0) -- Ancient Lichen
+,(22788, 1, 0) -- Flame Cap
+,(22787, 1, 0) -- Ragveil
+,(22575, 1, 0) -- Mote of Life
+,(22795, 1, 0) -- Fel Blossom
+,(22576, 1, 0) -- Mote of Mana
+,(27859, 1, 0) -- Zangar Caps
+,(19726, 1, 0) -- Bloodvine
+,(13468, 1, 0) -- Black Lotus
+,(22785, 1, 0) -- Felweed
+,(22789, 1, 0) -- Terocone
+,(22786, 1, 0) -- Dreaming Glory
+,(13467, 1, 0) -- Icecap
+,(13466, 1, 0) -- Plaguebloom
+,(13465, 1, 0) -- Mountain Silversage
+,(13463, 1, 0) -- Dreamfoil
+,(13464, 1, 0) -- Golden Sansam
+,(8846, 1, 0) -- Gromsblood
+,(8839, 1, 0) -- Blindweed
+,(8845, 1, 0) -- Ghost Mushroom
+,(8838, 1, 0) -- Sungrass
+,(8836, 1, 0) -- Arthas' Tears
+,(8831, 1, 0) -- Purple Lotus
+,(4625, 1, 0) -- Firebloom
+,(8153, 1, 0) -- Wildvine
+,(3819, 1, 0) -- Wintersbite
+,(3358, 1, 0) -- Khadgar's Whisker
+,(3821, 1, 0) -- Goldthorn
+,(3818, 1, 0) -- Fadeleaf
+,(3357, 1, 0) -- Liferoot
+,(3356, 1, 0) -- Kingsblood
+,(3355, 1, 0) -- Wild Steelbloom
+,(3369, 1, 0) -- Grave Moss
+,(3820, 1, 0) -- Stranglekelp
+,(2453, 1, 0) -- Bruiseweed
+,(2452, 1, 0) -- Swiftthistle
+,(2450, 1, 0) -- Briarthorn
+,(2449, 1, 0) -- Earthroot
+,(785, 1, 0) -- Mageroyal
+,(765, 1, 0) -- Silverleaf
+,(2447, 1, 0) -- Peacebloom
+,(22710, 1, 0) -- Bloodthistle
 
 /* Enchanting (50+) */
 -- Enchanting is in a separate query as all items need sell prices
 
-/* Mining: Trade Goods (Ores, Stone, Elements) (50+) */
-,(11370, 1, 0) -- (50)
-,(7076, 1, 0) -- Kinda annoying to get
-,(23424, 3, 0)
-,(23425, 3, 0)
-,(22573, 2, 0)
-,(22574, 1, 0)
-,(23426, 1, 0)
-,(23427, 1, 0) -- (70)
+/* Mining: Gathered (0-80) */
+,(36918, 3, 0) -- Scarlet Ruby
+,(36933, 3, 0) -- Forest Emerald
+,(36927, 3, 0) -- Twilight Opal
+,(36921, 3, 0) -- Autumn's Glow
+,(36930, 3, 0) -- Monarch Topaz
+,(36924, 3, 0) -- Sky Sapphire
+,(36910, 3, 0) -- Titanium Ore
+,(36929, 3, 0) -- Huge Citrine
+,(36923, 3, 0) -- Chalcedony
+,(36932, 3, 0) -- Dark Jade
+,(36926, 3, 0) -- Shadow Crystal
+,(36920, 3, 0) -- Sun Crystal
+,(36917, 3, 0) -- Bloodstone
+,(36912, 3, 0) -- Saronite Ore
+,(36909, 3, 0) -- Cobalt Ore -- End of WoTLK items
+,(32230, 1, 0) -- Shadowsong Amethyst -- Start of TBC Items
+,(32229, 1, 0) -- Lionseye
+,(32249, 1, 0) -- Seaspray Emerald
+,(32228, 1, 0) -- Empyrean Sapphire
+,(32231, 1, 0) -- Pyrestone
+,(32227, 1, 0) -- Crimson Spinel
+,(23439, 1, 0) -- Noble Topaz
+,(23437, 1, 0) -- Talasite
+,(23441, 1, 0) -- Nightseye
+,(23436, 1, 0) -- Living Ruby
+,(23440, 1, 0) -- Dawnstone
+,(23438, 1, 0) -- Star of Elune
+,(23426, 1, 0) -- Khorium Ore
+,(23427, 1, 0) -- Eternium Ore
+,(32464, 1, 0) -- Nethercite Ore
+,(23077, 1, 0) -- Blood Garnet
+,(23112, 1, 0) -- Golden Draenite
+,(23107, 1, 0) -- Shadow Draenite
+,(21929, 1, 0) -- Flame Spessarite
+,(23079, 1, 0) -- Deep Peridot
+,(23117, 1, 0) -- Azure Moonstone
+,(23425, 1, 0) -- Adamantite Ore
+,(22574, 1, 0) -- Mote of Fire
+,(22573, 1, 0) -- Mote of Earth
+,(12363, 1, 0) -- Arcane Crystal
+,(12364, 1, 0) -- Huge Emerald
+,(12800, 1, 0) -- Azerothian Diamond
+,(23424, 1, 0) -- Fel Iron Ore
 
-/* Mining: Non Trade Goods (Gems + a few other things) (50+) */
-,(7910, 3, 0) -- (50)
-,(11382, 3, 0)
-,(19774, 3, 0)
-,(12799, 3, 0)
-,(12361, 3, 0)
-,(12800, 3, 0)
-,(12363, 3, 0)
-,(12364, 3, 0) -- (60)
-,(23112, 2, 0)
-,(23117, 2, 0)
-,(23077, 2, 0)
-,(23079, 2, 0)
-,(21929, 2, 0)
-,(23107, 2, 0)
--- ,(32464, 2, 0) -- (70) -- Quest item only
-,(23436, 1, 0)  -- 70 blue gems
-,(23437, 1, 0)
-,(23438, 1, 0)
-,(23439, 1, 0)
-,(23440, 1, 0)
-,(23441, 1, 0)
-,(32227, 1, 0) -- 70 Purple gems. ENDGAME Raid drops. 
-,(32228, 1, 0)
-,(32229, 1, 0)
-,(32230, 1, 0)
-,(32231, 1, 0)
-,(32249, 1, 0)
--- WOTLK GEMS RAW --
--- Greens
-,(36917, 1, 0) -- Bloodstone
-,(36920, 1, 0) -- Sun Crystal
-,(36923, 1, 0) -- Chalcedony
-,(36926, 1, 0) -- Shadow Crystal
-,(36929, 1, 0) -- Huge Citrine
-,(36932, 1, 0) -- Dark Jade
--- Blues
-,(36918, 1, 0) -- Scarlet Ruby
-,(36921, 1, 0) -- Autumn's Glow
-,(36924, 1, 0) -- Sky Sapphire
-,(36927, 1, 0) -- Twilight Opal
-,(36930, 1, 0) -- Monarch Topaz
-,(36933, 1, 0) -- Forest Emerald
--- Purples
+,(12799, 1, 0) -- Large Opal
+,(12361, 1, 0) -- Blue Sapphire
+,(7076, 1, 0) -- Essence of Earth
+,(19774, 1, 0) -- Souldarite
+,(11382, 1, 0) -- Blood of the Mountain
+,(7910, 1, 0) -- Star Ruby
+,(11370, 1, 0) -- Dark Iron Ore
+,(7909, 1, 0) -- Aquamarine
+,(12365, 1, 0) -- Dense Stone
+,(3864, 1, 0) -- Citrine
+,(7911, 1, 0) -- Truesilver Ore
+,(9262, 1, 0) -- Black Vitriol
+,(3858, 1, 0) -- Mithril Ore
+,(10620, 1, 0) -- Thorium Ore
+,(1529, 1, 0) -- Jade
+,(7912, 1, 0) -- Solid Stone
+,(1705, 1, 0) -- Lesser Moonstone
+,(2772, 1, 0) -- Iron Ore
+,(2776, 1, 0) -- Gold Ore
+,(1206, 1, 0) -- Moss Agate
+,(2838, 1, 0) -- Heavy Stone
+,(3340, 1, 0) -- Incendicite Ore
+,(1210, 1, 0) -- Shadowgem
+,(2771, 1, 0) -- Tin Ore
+,(818, 1, 0) -- Tigerseye
+,(2836, 1, 0) -- Coarse Stone
+,(2775, 1, 0) -- Silver Ore
+,(2770, 1, 0) -- Copper Ore
+,(774, 1, 0) -- Malachite
+,(2835, 1, 0) -- Rough Stone
+,(5075, 1, 0) -- Blood Shard
+,(36728, 1, 0) -- Ice Shard Cluster
+,(22203, 1, 0) -- Large Obsidian Shard
+,(22634, 1, 0) -- Underlight Ore
+,(22202, 1, 0) -- Small Obsidian Shard
+,(5833, 1, 0) -- Indurium Ore
+,(2798, 1, 0) -- Rethban Ore
+,(11513, 1, 0) -- Tainted Vitriol
+,(4278, 1, 0) -- Lesser Bloodstone Ore
+,(11754, 1, 0) -- Black Diamond
+
+/* Prospect-only Gems (WoTLK Purple) */
 ,(36919, 1, 0) -- Cardinal Ruby
 ,(36922, 1, 0) -- King's Amber
 ,(36925, 1, 0) -- Majestic Zircon
@@ -85,317 +164,495 @@ VALUES
 ,(36931, 1, 0) -- Ametrine
 ,(36934, 1, 0) -- Eye of Zul
 
-/* Skinning (60+) | No leather scraps */
-,(4234, 3, 0) -- Heavy Leather
-,(4304, 3, 0) -- Thick Leather
-,(8170, 3, 0) -- Rugged Leather
-
-,(29548, 1, 0) -- (60)
-,(29547, 1, 0)
-,(29539, 1, 0)
-,(25708, 1, 0)
-,(25700, 1, 0)
-,(25699, 1, 0)
-,(21887, 3, 0) -- Primary trade good
-,(19768, 1, 0)
-,(19767, 1, 0)
-,(17012, 1, 0)
-,(15414, 1, 0)
-,(15410, 1, 0)
-,(22578, 2, 0)
-,(22577, 2, 0)
--- ,(22576, 2, 0) Excluded: Included in Herbalism section instead
-,(22572, 2, 0)
-,(25707, 1, 0) -- (70)
-
--- Leatherworking Mats Northrend
-
-,(33568, 3, 0) -- Borean Leather
-,(38558, 1, 0) -- Nerubian Chitin
+/* Skinning: Gathered (0-80) */
+,(44128, 3, 0) -- Arctic Fur
 ,(38561, 1, 0) -- Jormungar Scale
 ,(38557, 1, 0) -- Icy Dragonscale
+,(39690, 1, 0) -- Volatile Blasting Trigger
+,(39681, 1, 0) -- Handful of Cobalt Bolts
+,(39682, 1, 0) -- Overcharged Capacitor
+,(25707, 1, 0) -- Fel Hide
+,(33568, 3, 0) -- Borean Leather
+,(38558, 1, 0) -- Nerubian Chitin
+,(39686, 1, 0) -- Neo-Dynamic Gear Assembly
+,(32470, 1, 0) -- Nethermine Flayer Hide
+,(22572, 1, 0) -- Mote of Air
+,(22578, 1, 0) -- Mote of Water
+,(22577, 1, 0) -- Mote of Shadow
+,(15410, 1, 0) -- Scale of Onyxia
+,(29539, 1, 0) -- Cobra Scales
+,(19768, 1, 0) -- Primal Tiger Leather
+,(19767, 1, 0) -- Primal Bat Leather
+,(29548, 1, 0) -- Nether Dragonscales
+,(25700, 1, 0) -- Fel Scales
+,(29547, 1, 0) -- Wind Scales
+,(21887, 1, 0) -- Knothide Leather
+,(25699, 1, 0) -- Crystal Infused Leather
+,(15414, 1, 0) -- Red Dragonscale
+,(25708, 1, 0) -- Thick Clefthoof Leather
+,(17012, 1, 0) -- Core Leather
+,(20501, 1, 0) -- Heavy Silithid Carapace
+,(20500, 1, 0) -- Light Silithid Carapace
+,(15416, 1, 0) -- Black Dragonscale
+,(15408, 1, 0) -- Heavy Scorpid Scale
+,(20498, 1, 0) -- Silithid Chitin
+,(8170, 1, 0) -- Rugged Leather
+,(15417, 1, 0) -- Devilsaur Leather
+,(15412, 1, 0) -- Green Dragonscale
+,(15415, 1, 0) -- Blue Dragonscale
+,(8171, 1, 0) -- Rugged Hide
 
--- ,(39686, 1, 0) -- Northrend
--- ,(39682, 1, 0)
--- ,(38558, 1, 0)
+,(15419, 1, 0) -- Warbear Leather
+,(15423, 1, 0) -- Chimera Leather
+,(15422, 1, 0) -- Frostsaber Leather
+,(7974, 1, 0) -- Zesty Clam Meat
+,(8165, 1, 0) -- Worn Dragonscale
+,(8154, 1, 0) -- Scorpid Scale
+,(4304, 1, 0) -- Thick Leather
+,(8169, 1, 0) -- Thick Hide
+,(8368, 1, 0) -- Thick Wolfhide
+,(8167, 1, 0) -- Turtle Scale
+,(4235, 1, 0) -- Heavy Hide
+,(4234, 1, 0) -- Heavy Leather
+,(7428, 1, 0) -- Shadowcat Hide
+,(2319, 1, 0) -- Medium Leather
+,(4232, 1, 0) -- Medium Hide
+,(783, 1, 0) -- Light Hide
+,(2318, 1, 0) -- Light Leather
+,(2934, 1, 0) -- Ruined Leather Scraps
+,(12731, 1, 0) -- Pristine Hide of the Beast
+,(12607, 1, 0) -- Brilliant Chromatic Scale
+,(17057, 1, 0) -- Shiny Fish Scales
+,(35229, 1, 0) -- Nether Residue
+,(8973, 1, 0) -- Thick Yeti Hide
+,(7286, 1, 0) -- Black Whelp Scale
+,(23677, 1, 0) -- Moongraze Buck Hide
+,(6471, 1, 0) -- Perfect Deviate Scale
+,(12366, 1, 0) -- Thick Yeti Fur
+,(7392, 1, 0) -- Green Whelp Scale
+,(18947, 1, 0) -- Rage Scar Yeti Hide
+,(6470, 1, 0) -- Deviate Scale
+,(11512, 1, 0) -- Patch of Tainted Skin
+,(7287, 1, 0) -- Red Whelp Scale
+,(42542, 1, 0) -- Stoic Mammoth Hide
 
 /* Alchemy */
-,(25868, 3, 0) -- (1) Skyfire Diamond
+,(46377, 1, 0) -- Flask of Endless Rage
+,(46379, 1, 0) -- Flask of Stoneblood
+,(46378, 1, 0) -- Flask of Pure Mojo
+,(46376, 1, 0) -- Flask of the Frost Wyrm
+
+,(41334, 1, 0) -- Earthsiege Diamond
+,(41266, 1, 0) -- Skyflare Diamond
+
+,(41163, 1, 0) -- Titanium Bar
+,(40081, 1, 0) -- Potion of Nightmares
+,(40215, 1, 0) -- Mighty Frost Protection Potion
+,(44331, 1, 0) -- Elixir of Lightning Speed
+,(40070, 1, 0) -- Spellpower Elixir
+,(40097, 1, 0) -- Elixir of Protection
+,(44327, 1, 0) -- Elixir of Deadly Strikes
+,(40216, 1, 0) -- Mighty Nature Protection Potion
+,(40078, 1, 0) -- Elixir of Mighty Fortitude
+,(40109, 1, 0) -- Elixir of Mighty Mageblood
+,(40213, 1, 0) -- Mighty Arcane Protection Potion
+,(44330, 1, 0) -- Elixir of Armor Piercing
+,(40068, 1, 0) -- Wrath Elixir
+,(40073, 1, 0) -- Elixir of Mighty Strength
+,(44325, 1, 0) -- Elixir of Accuracy
+,(33448, 3, 0) -- Runic Mana Potion
+,(40214, 1, 0) -- Mighty Fire Protection Potion
+,(44939, 1, 0) -- Lesser Flask of Resistance
+,(40076, 1, 0) -- Guru's Elixir
+,(40212, 1, 0) -- Potion of Wild Magic
+,(40093, 1, 0) -- Indestructible Potion
+,(44329, 1, 0) -- Elixir of Expertise
+,(39666, 1, 0) -- Elixir of Mighty Agility
+,(33447, 3, 0) -- Runic Healing Potion
+,(40217, 1, 0) -- Mighty Shadow Protection Potion
+,(44332, 1, 0) -- Elixir of Mighty Thoughts
+,(40072, 1, 0) -- Elixir of Spirit
+,(40211, 1, 0) -- Potion of Speed
+,(40087, 1, 0) -- Powerful Rejuvenation Potion
+,(44328, 1, 0) -- Elixir of Mighty Defense
+,(40079, 1, 0) -- Lesser Flask of Toughness
+
+,(39671, 1, 0) -- Resurgent Healing Potion
+,(44958, 1, 0) -- Ethereal Oil
+,(22849, 1, 0) -- Ironshield Potion
+
+,(25868, 3, 0) -- Skyfire Diamond
 ,(25867, 3, 0) -- Earthstorm Diamond
-,(22841, 3, 0) -- Major Fire Protection Potion
-,(22866, 1, 3) -- Flask of Pure Death
-,(32852, 3, 1) -- Cauldron of Major Shadow Protection
-,(22845, 3, 0) -- Major Arcane Protection Potion
-,(22836, 3, 0) -- Major Dreamless Sleep Potion
-,(22851, 1, 3) -- Flask of Fortification
-,(32839, 3, 1) -- Cauldron of Major Arcane Protection
-,(22848, 1, 3) -- Elixir of Empowerment
-,(22839, 3, 0) -- Destruction Potion
-,(22861, 1, 3) -- Flask of Blinding Light
-,(32851, 3, 1) -- Cauldron of Major Nature Protection
-,(22844, 3, 0) -- Major Nature Protection Potion
-,(22835, 1, 3) -- Elixir of Major Shadow Power
-,(22847, 3, 0) -- Major Holy Protection Potion
-,(22838, 3, 0) -- Haste Potion
-,(22854, 1, 3) -- Flask of Relentless Assault
-,(32850, 3, 1) -- Cauldron of Major Frost Protection
-,(22842, 3, 0) -- Major Frost Protection Potion
-,(33208, 1, 3) -- Flask of Chromatic Wonder
-,(22846, 3, 0) -- Major Shadow Protection Potion
-,(22837, 3, 0) -- Heroic Potion
-,(22853, 1, 3) -- Flask of Mighty Restoration
-,(32849, 3, 1) -- Cauldron of Major Fire Protection
-,(22840, 1, 3) -- Elixir of Major Mageblood
-,(31676, 3, 0) -- Fel Regeneration Potion
-,(22834, 1, 3) -- Elixir of Major Defense
-,(22832, 3, 0) -- Super Mana Potion
-,(22871, 3, 0) -- Shrouding Potion
-,(31679, 1, 3) -- Fel Strength Elixir
-,(32068, 1, 3) -- Elixir of Ironskin
-,(22831, 1, 3) -- Elixir of Major Agility
-,(23571, 3, 0) -- Primal Might
-,(22456, 3, 0) -- Primal Shadow
-,(21884, 3, 0) -- Primal Fire
-,(22451, 3, 0) -- Primal Air
-,(21886, 3, 0) -- Primal Life
-,(22452, 3, 0) -- Primal Earth
-,(22457, 3, 0) -- Primal Mana
-,(21885, 3, 0) -- Primal Water
-,(22830, 1, 3) -- Elixir of the Searching Eye
-,(22829, 3, 0) -- Super Healing Potion
-,(22827, 1, 3) -- Elixir of Major Frost Power
-,(22833, 1, 3) -- Elixir of Major Firepower
-,(22828, 3, 0) -- Insane Strength Potion
-,(32067, 1, 3) -- Elixir of Draenic Wisdom
-,(32063, 1, 3) -- Earthen Elixir
-,(28104, 1, 3) -- Elixir of Mastery
-,(22826, 3, 0) -- Sneaking Potion
 
-,(28101, 3, 0) -- (51) Unstable Mana Potion
-,(22825, 1, 3) -- Elixir of Healing Power
-,(32062, 1, 3) -- Elixir of Major Fortitude
-,(22824, 1, 3) -- Elixir of Major Strength
-,(22823, 1, 3) -- Elixir of Camouflage
-,(13506, 3, 0) -- Potion of Petrification
-,(13512, 1, 3) -- Flask of Supreme Power
-,(20002, 3, 0) -- Greater Dreamless Sleep Potion
-,(18253, 3, 0) -- Major Rejuvenation Potion
-,(28103, 1, 3) -- Adept's Elixir
-,(13511, 1, 3) -- Flask of Distilled Wisdom
-,(28102, 1, 3) -- Onslaught Elixir
-,(13510, 1, 3) -- Flask of the Titans
-,(13513, 1, 3) -- Flask of Chromatic Resistance
-,(28100, 3, 0) -- Volatile Healing Potion
-,(13444, 3, 0) -- Major Mana Potion
-,(13458, 3, 0) -- Greater Nature Protection Potion
-,(13460, 3, 0) -- Greater Holy Protection Potion
-,(13456, 3, 0) -- Greater Frost Protection Potion
-,(13459, 3, 0) -- Greater Shadow Protection Potion
-,(13457, 3, 0) -- Greater Fire Protection Potion
-,(20004, 1, 3) -- Mighty Troll's Blood Elixir
-,(13461, 3, 0) -- Greater Arcane Protection Potion
-,(13462, 3, 0) -- Purification Potion
-,(13454, 1, 3) -- Greater Arcane Elixir
-,(20008, 3, 0) -- Living Action Potion
-,(13452, 1, 3) -- Elixir of the Mongoose
-,(13455, 3, 0) -- Greater Stoneshield Potion
-,(12803, 3, 0) -- Living Essence
--- ,(7076, 3, 0) -- Essence of Earth -- Already included in 'mining' section
-,(12808, 3, 0) -- Essence of Undeath
-,(12360, 3, 0) -- Arcanite Bar
-,(7078, 3, 0) -- Essence of Fire
-,(7082, 3, 0) -- Essence of Air
-,(7080, 3, 0) -- Essence of Water
-,(13446, 3, 0) -- Major Healing Potion
-,(3386, 3, 0) -- Potion of Curing
-,(13453, 1, 3) -- Elixir of Brute Force
-,(13447, 1, 3) -- Elixir of the Sages
-,(13445, 1, 3) -- Elixir of Superior Defense
-,(13443, 3, 0) -- Superior Mana Potion
-,(13442, 3, 0) -- Mighty Rage Potion
-,(6037, 3, 0) -- Truesilver Bar
-,(9224, 1, 3) -- Elixir of Demonslaying
-,(21546, 1, 3) -- Elixir of Greater Firepower
-,(3387, 3, 0) -- Limited Invulnerability Potion
-,(13423, 3, 0) -- Stonescale Oil
-,(9264, 1, 3) -- Elixir of Shadow Power
-,(20007, 1, 3) -- Mageblood Elixir
-,(8827, 1, 3) -- Elixir of Water Walking
+,(22841, 1, 0) -- Major Fire Protection Potion
+,(33208, 1, 0) -- Flask of Chromatic Wonder
+,(22854, 1, 0) -- Flask of Relentless Assault
+,(32839, 1, 0) -- Cauldron of Major Arcane Protection
+,(22845, 1, 0) -- Major Arcane Protection Potion
+,(22836, 1, 0) -- Major Dreamless Sleep Potion
+,(32851, 1, 0) -- Cauldron of Major Nature Protection
+,(22848, 1, 0) -- Elixir of Empowerment
+,(22839, 1, 0) -- Destruction Potion
+,(22853, 1, 0) -- Flask of Mighty Restoration
+,(22844, 1, 0) -- Major Nature Protection Potion
+,(22835, 1, 0) -- Elixir of Major Shadow Power
+,(22866, 1, 0) -- Flask of Pure Death
+,(32850, 1, 0) -- Cauldron of Major Frost Protection
+,(22847, 1, 0) -- Major Holy Protection Potion
+,(22838, 1, 0) -- Haste Potion
+,(22851, 1, 0) -- Flask of Fortification
+,(22842, 1, 0) -- Major Frost Protection Potion
+,(22861, 1, 0) -- Flask of Blinding Light
+,(32849, 1, 0) -- Cauldron of Major Fire Protection
+,(22846, 1, 0) -- Major Shadow Protection Potion
+,(22837, 1, 0) -- Heroic Potion
+,(22840, 1, 0) -- Elixir of Major Mageblood
+,(32852, 1, 0) -- Cauldron of Major Shadow Protection
+,(31676, 1, 0) -- Fel Regeneration Potion
+,(22834, 1, 0) -- Elixir of Major Defense
+,(22832, 1, 0) -- Super Mana Potion
+,(31679, 1, 0) -- Fel Strength Elixir
+,(22871, 1, 0) -- Shrouding Potion
+,(32068, 1, 0) -- Elixir of Ironskin
+,(22831, 1, 0) -- Elixir of Major Agility
+,(23571, 1, 0) -- Primal Might
+,(21884, 1, 0) -- Primal Fire
+,(21886, 1, 0) -- Primal Life
+,(22451, 1, 0) -- Primal Air
+,(22457, 1, 0) -- Primal Mana
+,(22452, 1, 0) -- Primal Earth
+,(22456, 1, 0) -- Primal Shadow
+,(21885, 1, 0) -- Primal Water
+,(22830, 1, 0) -- Elixir of the Searching Eye
 
-,(9233, 1, 3) -- (101) Elixir of Detect Demon
+,(22829, 1, 0) -- Super Healing Potion
+,(22827, 1, 0) -- Elixir of Major Frost Power
+,(22833, 1, 0) -- Elixir of Major Firepower
+,(32067, 1, 0) -- Elixir of Draenic Wisdom
+,(22828, 1, 0) -- Insane Strength Potion
+,(28104, 1, 0) -- Elixir of Mastery
+,(32063, 1, 0) -- Earthen Elixir
+,(22826, 1, 0) -- Sneaking Potion
+,(28101, 1, 0) -- Unstable Mana Potion
+,(32062, 1, 0) -- Elixir of Major Fortitude
+,(22825, 1, 0) -- Elixir of Healing Power
+,(22824, 1, 0) -- Elixir of Major Strength
+,(22823, 1, 0) -- Elixir of Camouflage
+,(13506, 1, 0) -- Potion of Petrification
+,(28102, 1, 0) -- Onslaught Elixir
+,(13512, 1, 0) -- Flask of Supreme Power
+,(20002, 1, 0) -- Greater Dreamless Sleep Potion
+,(18253, 1, 0) -- Major Rejuvenation Potion
+,(13511, 1, 0) -- Flask of Distilled Wisdom
+,(28100, 1, 0) -- Volatile Healing Potion
+,(13510, 1, 0) -- Flask of the Titans
+,(28103, 1, 0) -- Adept's Elixir
+,(13513, 1, 0) -- Flask of Chromatic Resistance
+,(13444, 1, 0) -- Major Mana Potion
+,(13458, 1, 0) -- Greater Nature Protection Potion
+,(13460, 1, 0) -- Greater Holy Protection Potion
+,(13456, 1, 0) -- Greater Frost Protection Potion
+,(13459, 1, 0) -- Greater Shadow Protection Potion
+,(13457, 1, 0) -- Greater Fire Protection Potion
+,(20004, 1, 0) -- Mighty Troll's Blood Elixir
+,(13461, 1, 0) -- Greater Arcane Protection Potion
+,(13462, 1, 0) -- Purification Potion
+,(13454, 1, 0) -- Greater Arcane Elixir
+,(20008, 1, 0) -- Living Action Potion
+,(13452, 1, 0) -- Elixir of the Mongoose
+,(13455, 1, 0) -- Greater Stoneshield Potion
+,(12803, 1, 0) -- Living Essence
+,(12808, 1, 0) -- Essence of Undeath
+,(12360, 1, 0) -- Arcanite Bar
+,(7078, 1, 0) -- Essence of Fire
+,(7082, 1, 0) -- Essence of Air
+,(7080, 1, 0) -- Essence of Water
+,(13446, 1, 0) -- Major Healing Potion
+,(3386, 1, 0) -- Potion of Curing
+,(13453, 1, 0) -- Elixir of Brute Force
+,(13447, 1, 0) -- Elixir of the Sages
+,(13445, 1, 0) -- Elixir of Superior Defense
+,(13443, 1, 0) -- Superior Mana Potion
+,(13442, 1, 0) -- Mighty Rage Potion
 
-/* Jewelcrafting */
--- Note: No purple gems included
+,(6037, 1, 0) -- Truesilver Bar
+,(9224, 1, 0) -- Elixir of Demonslaying
+,(13423, 1, 0) -- Stonescale Oil
+,(3387, 1, 0) -- Limited Invulnerability Potion
+,(21546, 1, 0) -- Elixir of Greater Firepower
+,(9264, 1, 0) -- Elixir of Shadow Power
+,(20007, 1, 0) -- Mageblood Elixir
+,(9233, 1, 0) -- Elixir of Detect Demon
+,(8827, 1, 0) -- Elixir of Water Walking
+,(9197, 1, 0) -- Elixir of Dream Vision
+,(9187, 1, 0) -- Elixir of Greater Agility
+,(9088, 1, 0) -- Gift of Arthas
+,(9206, 1, 0) -- Elixir of Giants
+,(9179, 1, 0) -- Elixir of Greater Intellect
+,(9155, 1, 0) -- Arcane Elixir
+,(9172, 1, 0) -- Invisibility Potion
+,(9154, 1, 0) -- Elixir of Detect Undead
+,(18294, 1, 0) -- Elixir of Greater Water Breathing
+,(3928, 1, 0) -- Superior Healing Potion
+,(12190, 1, 0) -- Dreamless Sleep Potion
+,(9144, 1, 0) -- Wildvine Potion
+,(4623, 1, 0) -- Lesser Stoneshield Potion
+,(9061, 1, 0) -- Goblin Rocket Fuel
+,(9036, 1, 0) -- Magic Resistance Potion
+,(9030, 1, 0) -- Restorative Potion
+,(6149, 1, 0) -- Greater Mana Potion
+,(8956, 1, 0) -- Oil of Immolation
+,(3829, 1, 0) -- Frost Oil
+,(10592, 1, 0) -- Catseye Elixir
+,(3828, 1, 0) -- Elixir of Detect Lesser Invisibility
+,(8951, 1, 0) -- Elixir of Greater Defense
+,(6050, 1, 0) -- Frost Protection Potion
+,(17708, 1, 0) -- Elixir of Frost Power
+,(6052, 1, 0) -- Nature Protection Potion
+,(8949, 1, 0) -- Elixir of Agility
+,(3826, 1, 0) -- Major Troll's Blood Elixir
+,(3825, 1, 0) -- Elixir of Fortitude
+,(5633, 1, 0) -- Great Rage Potion
+,(3824, 1, 0) -- Shadow Oil
+,(3823, 1, 0) -- Lesser Invisibility Potion
+,(6049, 1, 0) -- Fire Protection Potion
+,(3827, 1, 0) -- Mana Potion
+,(1710, 1, 0) -- Greater Healing Potion
+,(3577, 1, 0) -- Gold Bar
+,(3391, 1, 0) -- Elixir of Ogre's Strength
+,(5634, 1, 0) -- Free Action Potion
+,(6373, 1, 0) -- Elixir of Firepower
+,(3390, 1, 0) -- Elixir of Lesser Agility
+,(6048, 1, 0) -- Shadow Protection Potion
 
-,(24029, 3, 0) -- (1) Teardrop Living Ruby
-,(24059, 3, 0) -- Potent Noble Topaz
-,(24039, 3, 0) -- Stormy Star of Elune
-,(24035, 3, 0) -- Sparkling Star of Elune
-,(24054, 3, 0) -- Sovereign Nightseye
-,(25901, 3, 0) -- Insightful Earthstorm Diamond
-,(31861, 3, 0) -- Great Dawnstone
-,(35503, 3, 0) -- Ember Skyfire Diamond
-,(24032, 3, 0) -- Subtle Living Ruby
-,(24062, 3, 0) -- Enduring Talasite
-,(31868, 3, 0) -- Wicked Noble Topaz
-,(24051, 3, 0) -- Rigid Dawnstone
-,(25896, 3, 0) -- Powerful Earthstorm Diamond
-,(35315, 3, 0) -- Quick Dawnstone
-,(24027, 3, 0) -- Bold Living Ruby
-,(24057, 3, 0) -- Royal Nightseye
-,(25894, 3, 0) -- Swift Skyfire Diamond
-,(31865, 3, 0) -- Infused Nightseye
-,(24037, 3, 0) -- Lustrous Star of Elune
-,(24067, 3, 0) -- Jagged Talasite
-,(24053, 3, 0) -- Mystic Dawnstone
-,(25899, 3, 0) -- Brutal Earthstorm Diamond
-,(35501, 3, 0) -- Eternal Earthstorm Diamond
-,(24031, 3, 0) -- Bright Living Ruby
-,(24061, 3, 0) -- Glinting Noble Topaz
-,(31867, 3, 0) -- Veiled Noble Topaz
-,(24048, 3, 0) -- Smooth Dawnstone
-,(34220, 3, 0) -- Chaotic Skyfire Diamond
-,(24056, 3, 0) -- Glowing Nightseye
-,(25893, 3, 0) -- Mystical Skyfire Diamond
--- ,(35945, 3, 0) -- Brilliant Glass -- Crafted by jewelcrafters + used by jewelcrafters - no sense selling on AH
-,(24033, 3, 0) -- Solid Star of Elune
-,(24065, 3, 0) -- Dazzling Talasite
-,(32410, 3, 0) -- Thundering Skyfire Diamond
-,(24052, 3, 0) -- Thick Dawnstone
-,(25898, 3, 0) -- Tenacious Earthstorm Diamond
-,(35318, 3, 0) -- Forceful Talasite
-,(24030, 3, 0) -- Runed Living Ruby
-,(24060, 3, 0) -- Luminous Noble Topaz
-,(24047, 3, 0) -- Brilliant Dawnstone
-,(33782, 3, 0) -- Steady Talasite
-,(24055, 3, 0) -- Shifting Nightseye
-,(25890, 3, 0) -- Destructive Skyfire Diamond
-,(35707, 3, 0) -- Regal Nightseye
-,(24036, 3, 0) -- Flashing Living Ruby
-,(24066, 3, 0) -- Radiant Talasite
-,(32409, 3, 0) -- Relentless Earthstorm Diamond
-,(24050, 3, 0) -- Gleaming Dawnstone
-,(25897, 3, 0) -- Bracing Earthstorm Diamond
-,(35316, 3, 0) -- Reckless Noble Topaz
+,(3389, 1, 0) -- Elixir of Defense
+,(6371, 1, 0) -- Fire Oil
+,(7068, 1, 0) -- Elemental Fire
+,(3388, 1, 0) -- Strong Troll's Blood Elixir
+,(3385, 1, 0) -- Lesser Mana Potion
+,(929, 1, 0) -- Healing Potion
+,(3384, 1, 0) -- Minor Magic Resistance Potion
+,(3383, 1, 0) -- Elixir of Wisdom
+,(6051, 1, 0) -- Holy Protection Potion
+,(45621, 1, 0) -- Elixir of Minor Accuracy
+,(6372, 1, 0) -- Swim Speed Potion
+,(6662, 1, 0) -- Elixir of Giant Growth
+,(5996, 1, 0) -- Elixir of Water Breathing
+,(2460, 1, 0) -- Elixir of Tongues (NYI)
+,(2456, 1, 0) -- Minor Rejuvenation Potion
+,(2459, 1, 0) -- Swiftness Potion
+,(2455, 1, 0) -- Minor Mana Potion
+,(6370, 1, 0) -- Blackmouth Oil
+,(4596, 1, 0) -- Discolored Healing Potion
+,(5631, 1, 0) -- Rage Potion
+,(858, 1, 0) -- Lesser Healing Potion
+,(2458, 1, 0) -- Elixir of Minor Fortitude
+,(2457, 1, 0) -- Elixir of Minor Agility
+,(3382, 1, 0) -- Weak Troll's Blood Elixir
+,(2454, 1, 0) -- Elixir of Lion's Strength
+,(118, 1, 0) -- Minor Healing Potion
+,(5997, 1, 0) -- Elixir of Minor Defense
+,(19931, 1, 0) -- Gurubashi Mojo Madness
+/* Jewelcrafting: Gems (Blue) */
+,(40119, 1, 0) -- Solid Majestic Zircon
+,(40120, 1, 0) -- Sparkling Majestic Zircon
+,(40121, 1, 0) -- Lustrous Majestic Zircon
+,(40122, 1, 0) -- Stormy Majestic Zircon
 
-,(24028, 3, 0) -- (51) Delicate Living Ruby
-,(24058, 3, 0) -- Inscribed Noble Topaz
-,(25895, 3, 0) -- Enigmatic Skyfire Diamond
-,(31863, 3, 0) -- Balanced Nightseye
--- Northrend Gem ,(39911, 3, 0) -- Runed Bloodstone
--- Northrend Gem ,(39944, 3, 0) -- Infused Shadow Crystal
--- Northrend Gem ,(39960, 3, 0) -- Wicked Huge Citrine
--- Northrend Gem ,(39984, 3, 0) -- Dazzling Dark Jade
--- Northrend Gem ,(39915, 3, 0) -- Rigid Sun Crystal
--- Northrend Gem ,(39949, 3, 0) -- Champion's Huge Citrine
--- Northrend Gem ,(39967, 3, 0) -- Resolute Huge Citrine
--- Northrend Gem ,(39992, 3, 0) -- Shattered Dark Jade
--- Northrend Gem ,(39936, 3, 0) -- Glowing Shadow Crystal
--- Northrend Gem ,(39946, 3, 0) -- Luminous Huge Citrine
--- Northrend Gem ,(39979, 3, 0) -- Seer's Dark Jade
--- Northrend Gem ,(39908, 3, 0) -- Flashing Bloodstone
--- Northrend Gem ,(39933, 3, 0) -- Puissant Shadow Crystal
--- Northrend Gem ,(39963, 3, 0) -- Stark Huge Citrine
--- Northrend Gem ,(39988, 3, 0) -- Opaque Dark Jade
--- Northrend Gem ,(39917, 3, 0) -- Mystic Sun Crystal
--- Northrend Gem ,(39952, 3, 0) -- Deadly Huge Citrine
--- Northrend Gem ,(39975, 3, 0) -- Vivid Dark Jade
--- Northrend Gem ,(39927, 3, 0) -- Lustrous Chalcedony
--- Northrend Gem ,(39900, 3, 0) -- Bold Bloodstone
--- Northrend Gem ,(39945, 3, 0) -- Mysterious Shadow Crystal
--- Northrend Gem ,(39958, 3, 0) -- Durable Huge Citrine
--- Northrend Gem ,(39982, 3, 0) -- Turbid Dark Jade
--- Northrend Gem ,(39914, 3, 0) -- Smooth Sun Crystal
--- Northrend Gem ,(39948, 3, 0) -- Etched Huge Citrine
--- Northrend Gem ,(39966, 3, 0) -- Accurate Huge Citrine
--- Northrend Gem ,(39991, 3, 0) -- Tense Dark Jade
--- Northrend Gem ,(39942, 3, 0) -- Tenuous Shadow Crystal
--- Northrend Gem ,(39955, 3, 0) -- Deft Huge Citrine
--- Northrend Gem ,(39978, 3, 0) -- Forceful Dark Jade
--- Northrend Gem ,(42701, 3, 0) -- Enchanted Pearl
--- Northrend Gem ,(39907, 3, 0) -- Subtle Bloodstone
--- Northrend Gem ,(39939, 3, 0) -- Defender's Shadow Crystal
--- Northrend Gem ,(39962, 3, 0) -- Empowered Huge Citrine
--- Northrend Gem ,(39986, 3, 0) -- Lambent Dark Jade
--- Northrend Gem ,(39918, 3, 0) -- Quick Sun Crystal
--- Northrend Gem ,(39951, 3, 0) -- Fierce Huge Citrine
--- Northrend Gem ,(39974, 3, 0) -- Jagged Dark Jade
--- Northrend Gem ,(39920, 3, 0) -- Sparkling Chalcedony
--- Northrend Gem ,(39943, 3, 0) -- Royal Shadow Crystal
--- Northrend Gem ,(39957, 3, 0) -- Veiled Huge Citrine
--- Northrend Gem ,(39981, 3, 0) -- Shining Dark Jade
--- Northrend Gem ,(39912, 3, 0) -- Brilliant Sun Crystal
--- Northrend Gem ,(39947, 3, 0) -- Inscribed Huge Citrine
--- Northrend Gem ,(39965, 3, 0) -- Glimmering Huge Citrine
--- Northrend Gem ,(39990, 3, 0) -- Radiant Dark Jade
+,(40008, 3, 0) -- Solid Sky Sapphire
+,(40009, 3, 0) -- Sparkling Sky Sapphire
+,(40010, 3, 0) -- Lustrous Sky Sapphire
+,(40011, 3, 0) -- Stormy Sky Sapphire
 
--- Northrend Gem ,(39935, 3, 0) -- (101) Shifting Shadow Crystal
--- Northrend Gem ,(39954, 3, 0) -- Lucent Huge Citrine
--- Northrend Gem ,(39977, 3, 0) -- Steady Dark Jade
--- Northrend Gem ,(39910, 3, 0) -- Precise Bloodstone
--- Northrend Gem ,(39906, 3, 0) -- Bright Bloodstone
--- Northrend Gem ,(39938, 3, 0) -- Regal Shadow Crystal
--- Northrend Gem ,(39961, 3, 0) -- Pristine Huge Citrine
--- Northrend Gem ,(39985, 3, 0) -- Sundered Dark Jade
--- Northrend Gem ,(39916, 3, 0) -- Thick Sun Crystal
--- Northrend Gem ,(39950, 3, 0) -- Resplendent Huge Citrine
--- Northrend Gem ,(39968, 3, 0) -- Timeless Dark Jade
--- Northrend Gem ,(39919, 3, 0) -- Solid Chalcedony
--- Northrend Gem ,(39941, 3, 0) -- Purified Shadow Crystal
--- Northrend Gem ,(39956, 3, 0) -- Potent Huge Citrine
--- Northrend Gem ,(39980, 3, 0) -- Misty Dark Jade
--- Northrend Gem ,(39909, 3, 0) -- Fractured Bloodstone
--- Northrend Gem ,(39940, 3, 0) -- Guardian's Shadow Crystal
--- Northrend Gem ,(39964, 3, 0) -- Stalwart Huge Citrine
--- Northrend Gem ,(39989, 3, 0) -- Energized Dark Jade
--- Northrend Gem ,(39934, 3, 0) -- Sovereign Shadow Crystal
--- Northrend Gem ,(39953, 3, 0) -- Glinting Huge Citrine
--- Northrend Gem ,(39976, 3, 0) -- Enduring Dark Jade
--- Northrend Gem ,(39932, 3, 0) -- Stormy Chalcedony
--- Northrend Gem ,(39905, 3, 0) -- Delicate Bloodstone
--- Northrend Gem ,(39937, 3, 0) -- Balanced Shadow Crystal
--- Northrend Gem ,(39959, 3, 0) -- Reckless Huge Citrine
--- Northrend Gem ,(39983, 3, 0) -- Intricate Dark Jade
--- ,(21780, 3, 0) -- Blood Crown
--- ,(21793, 3, 0) -- Arcanite Sword Pendant
--- ,(21779, 3, 0) -- Band of Natural Fire
--- ,(21792, 3, 0) -- Necklace of the Diamond Tower
-,(32836, 3, 0) -- Purified Shadow Pearl
-,(31079, 3, 0) -- Mercurial Adamantite
-,(23101, 3, 0) -- Potent Flame Spessarite
-,(28290, 3, 0) -- Smooth Golden Draenite
-,(31866, 3, 0) -- Veiled Flame Spessarite
-,(23110, 3, 0) -- Shifting Shadow Draenite
-,(23096, 3, 0) -- Runed Blood Garnet
-,(23119, 3, 0) -- Sparkling Azure Moonstone
--- ,(45054, 3, 0) -- Prismatic Black Diamond -- Jewelcrafting intermediary crafting item. No sense selling
-,(23105, 3, 0) -- Enduring Deep Peridot
-,(23114, 3, 0) -- Gleaming Golden Draenite
-,(23099, 3, 0) -- Luminous Flame Spessarite
-,(23109, 3, 0) -- Royal Shadow Draenite
-,(32833, 3, 0) -- Purified Jaggal Pearl
-,(23095, 3, 0) -- Bold Blood Garnet
-,(23118, 3, 0) -- Solid Azure Moonstone
-,(31860, 3, 0) -- Great Golden Draenite
-,(23104, 3, 0) -- Jagged Deep Peridot
-,(23113, 3, 0) -- Brilliant Golden Draenite
+/* Jewelcrafting: Gems (Green) */
+,(40164, 1, 0) -- Timeless Eye of Zul
+,(40165, 1, 0) -- Jagged Eye of Zul
+,(40166, 1, 0) -- Vivid Eye of Zul
+,(40167, 1, 0) -- Enduring Eye of Zul
+,(40168, 1, 0) -- Steady Eye of Zul
+,(40169, 1, 0) -- Forceful Eye of Zul
+,(40170, 1, 0) -- Seer's Eye of Zul
+,(40171, 1, 0) -- Misty Eye of Zul
+,(40172, 1, 0) -- Shining Eye of Zul
+,(40173, 1, 0) -- Turbid Eye of Zul
+,(40174, 1, 0) -- Intricate Eye of Zul
+,(40175, 1, 0) -- Dazzling Eye of Zul
+,(40176, 1, 0) -- Sundered Eye of Zul
+,(40177, 1, 0) -- Lambent Eye of Zul
+,(40178, 1, 0) -- Opaque Eye of Zul
+,(40179, 1, 0) -- Energized Eye of Zul
+,(40180, 1, 0) -- Radiant Eye of Zul
+,(40181, 1, 0) -- Tense Eye of Zul
+,(40182, 1, 0) -- Shattered Eye of Zul
 
-,(23121, 3, 0) -- (151) Lustrous Azure Moonstone
-,(31864, 3, 0) -- Infused Shadow Draenite
-,(23098, 3, 0) -- Inscribed Flame Spessarite
-,(23108, 3, 0) -- Glowing Shadow Draenite
-,(23094, 3, 0) -- Teardrop Blood Garnet
-,(23116, 3, 0) -- Rigid Golden Draenite
-,(23103, 3, 0) -- Radiant Deep Peridot
-,(28595, 3, 0) -- Bright Blood Garnet
-,(31869, 3, 0) -- Wicked Flame Spessarite
-,(23111, 3, 0) -- Sovereign Shadow Draenite
-,(23097, 3, 0) -- Delicate Blood Garnet
-,(23120, 3, 0) -- Stormy Azure Moonstone
-,(31862, 3, 0) -- Balanced Shadow Draenite
-,(23106, 3, 0) -- Dazzling Deep Peridot
-,(23115, 3, 0) -- Thick Golden Draenite
-,(23100, 3, 0) -- Glinting Flame Spessarite
+,(40085, 3, 0) -- Timeless Forest Emerald
+,(40086, 3, 0) -- Jagged Forest Emerald
+,(40088, 3, 0) -- Vivid Forest Emerald
+,(40089, 3, 0) -- Enduring Forest Emerald
+,(40090, 3, 0) -- Steady Forest Emerald
+,(40091, 3, 0) -- Forceful Forest Emerald
+,(40092, 3, 0) -- Seer's Forest Emerald
+,(40094, 3, 0) -- Dazzling Forest Emerald
+,(40095, 3, 0) -- Misty Forest Emerald
+,(40096, 3, 0) -- Sundered Forest Emerald
+,(40098, 3, 0) -- Radiant Forest Emerald
+,(40099, 3, 0) -- Shining Forest Emerald
+,(40100, 3, 0) -- Lambent Forest Emerald
+,(40101, 3, 0) -- Tense Forest Emerald
+,(40102, 3, 0) -- Turbid Forest Emerald
+,(40103, 3, 0) -- Opaque Forest Emerald
+,(40104, 3, 0) -- Intricate Forest Emerald
+,(40105, 3, 0) -- Energized Forest Emerald
+,(40106, 3, 0) -- Shattered Forest Emerald
+
+/* Jewelcrafting: Gems (Meta) */
+,(41285, 1, 0) -- Chaotic Skyflare Diamond
+,(41307, 1, 0) -- Destructive Skyflare Diamond
+,(41333, 1, 0) -- Ember Skyflare Diamond
+,(41335, 1, 0) -- Enigmatic Skyflare Diamond
+,(41339, 1, 0) -- Swift Skyflare Diamond
+,(41375, 1, 0) -- Tireless Skyflare Diamond
+,(41376, 1, 0) -- Revitalizing Skyflare Diamond
+,(41377, 1, 0) -- Effulgent Skyflare Diamond
+,(41378, 1, 0) -- Forlorn Skyflare Diamond
+,(41379, 1, 0) -- Impassive Skyflare Diamond
+,(41400, 1, 0) -- Thundering Skyflare Diamond
+
+,(41380, 1, 0) -- Austere Earthsiege Diamond
+,(41381, 1, 0) -- Persistent Earthsiege Diamond
+,(41382, 1, 0) -- Trenchant Earthsiege Diamond
+,(41385, 1, 0) -- Invigorating Earthsiege Diamond
+,(41389, 1, 0) -- Beaming Earthsiege Diamond
+,(41395, 1, 0) -- Bracing Earthsiege Diamond
+,(41396, 1, 0) -- Eternal Earthsiege Diamond
+,(41397, 1, 0) -- Powerful Earthsiege Diamond
+,(41398, 1, 0) -- Relentless Earthsiege Diamond
+,(41401, 1, 0) -- Insightful Earthsiege Diamond
+
+/* Jewelcrafting: Gems (Orange) */
+,(40142, 1, 0) -- Inscribed Ametrine
+,(40143, 1, 0) -- Etched Ametrine
+,(40144, 1, 0) -- Champion's Ametrine
+,(40145, 1, 0) -- Resplendent Ametrine
+,(40146, 1, 0) -- Fierce Ametrine
+,(40147, 1, 0) -- Deadly Ametrine
+,(40148, 1, 0) -- Glinting Ametrine
+,(40149, 1, 0) -- Lucent Ametrine
+,(40150, 1, 0) -- Deft Ametrine
+,(40151, 1, 0) -- Luminous Ametrine
+,(40152, 1, 0) -- Potent Ametrine
+,(40153, 1, 0) -- Veiled Ametrine
+,(40154, 1, 0) -- Durable Ametrine
+,(40155, 1, 0) -- Reckless Ametrine
+,(40156, 1, 0) -- Wicked Ametrine
+,(40157, 1, 0) -- Pristine Ametrine
+,(40158, 1, 0) -- Empowered Ametrine
+,(40159, 1, 0) -- Stark Ametrine
+,(40160, 1, 0) -- Stalwart Ametrine
+,(40161, 1, 0) -- Glimmering Ametrine
+,(40162, 1, 0) -- Accurate Ametrine
+,(40163, 1, 0) -- Resolute Ametrine
+
+,(40037, 3, 0) -- Inscribed Monarch Topaz
+,(40038, 3, 0) -- Etched Monarch Topaz
+,(40039, 3, 0) -- Champion's Monarch Topaz
+,(40040, 3, 0) -- Resplendent Monarch Topaz
+,(40041, 3, 0) -- Fierce Monarch Topaz
+,(40043, 3, 0) -- Deadly Monarch Topaz
+,(40044, 3, 0) -- Glinting Monarch Topaz
+,(40045, 3, 0) -- Lucent Monarch Topaz
+,(40046, 3, 0) -- Deft Monarch Topaz
+,(40047, 3, 0) -- Luminous Monarch Topaz
+,(40048, 3, 0) -- Potent Monarch Topaz
+,(40049, 3, 0) -- Veiled Monarch Topaz
+,(40050, 3, 0) -- Durable Monarch Topaz
+,(40051, 3, 0) -- Reckless Monarch Topaz
+,(40052, 3, 0) -- Wicked Monarch Topaz
+,(40053, 3, 0) -- Pristine Monarch Topaz
+,(40054, 3, 0) -- Empowered Monarch Topaz
+,(40055, 3, 0) -- Stark Monarch Topaz
+,(40056, 3, 0) -- Stalwart Monarch Topaz
+,(40057, 3, 0) -- Glimmering Monarch Topaz
+,(40058, 3, 0) -- Accurate Monarch Topaz
+,(40059, 3, 0) -- Resolute Monarch Topaz
+
+/* Jewelcrafting: Gems (Prismatic) */
+,(49110, 3, 0) -- Nightmare Tear
+,(42702, 3, 0) -- Enchanted Tear
+
+/* Jewelcrafting: Gems (Purple) */
+,(40129, 1, 0) -- Sovereign Dreadstone
+,(40130, 1, 0) -- Shifting Dreadstone
+,(40131, 1, 0) -- Tenuous Dreadstone
+,(40132, 1, 0) -- Glowing Dreadstone
+,(40133, 1, 0) -- Purified Dreadstone
+,(40134, 1, 0) -- Royal Dreadstone
+,(40135, 1, 0) -- Mysterious Dreadstone
+,(40136, 1, 0) -- Balanced Dreadstone
+,(40137, 1, 0) -- Infused Dreadstone
+,(40138, 1, 0) -- Regal Dreadstone
+,(40139, 1, 0) -- Defender's Dreadstone
+,(40140, 1, 0) -- Puissant Dreadstone
+,(40141, 1, 0) -- Guardian's Dreadstone
+
+,(40022, 3, 0) -- Sovereign Twilight Opal
+,(40023, 3, 0) -- Shifting Twilight Opal
+,(40024, 3, 0) -- Tenuous Twilight Opal
+,(40025, 3, 0) -- Glowing Twilight Opal
+,(40026, 3, 0) -- Purified Twilight Opal
+,(40027, 3, 0) -- Royal Twilight Opal
+,(40028, 3, 0) -- Mysterious Twilight Opal
+,(40029, 3, 0) -- Balanced Twilight Opal
+,(40030, 3, 0) -- Infused Twilight Opal
+,(40031, 3, 0) -- Regal Twilight Opal
+,(40032, 3, 0) -- Defender's Twilight Opal
+,(40033, 3, 0) -- Puissant Twilight Opal
+,(40034, 3, 0) -- Guardian's Twilight Opal
+
+/* Jewelcrafting: Gems (Red) */
+,(40111, 3, 0) -- Bold Cardinal Ruby
+,(40112, 3, 0) -- Delicate Cardinal Ruby
+,(40113, 3, 0) -- Runed Cardinal Ruby
+,(40114, 3, 0) -- Bright Cardinal Ruby
+,(40115, 3, 0) -- Subtle Cardinal Ruby
+,(40116, 3, 0) -- Flashing Cardinal Ruby
+,(40117, 3, 0) -- Fractured Cardinal Ruby
+,(40118, 3, 0) -- Precise Cardinal Ruby
+
+,(39996, 3, 0) -- Bold Scarlet Ruby
+,(39997, 3, 0) -- Delicate Scarlet Ruby
+,(39998, 3, 0) -- Runed Scarlet Ruby
+,(39999, 3, 0) -- Bright Scarlet Ruby
+,(40000, 3, 0) -- Subtle Scarlet Ruby
+,(40001, 3, 0) -- Flashing Scarlet Ruby
+,(40002, 3, 0) -- Fractured Scarlet Ruby
+,(40003, 3, 0) -- Precise Scarlet Ruby
+
+/* Jewelcrafting: Gems (Yellow) */
+,(40123, 1, 0) -- Brilliant King's Amber
+,(40124, 1, 0) -- Smooth King's Amber
+,(40125, 1, 0) -- Rigid King's Amber
+,(40126, 1, 0) -- Thick King's Amber
+,(40127, 1, 0) -- Mystic King's Amber
+,(40128, 1, 0) -- Quick King's Amber
+
+,(40012, 3, 0) -- Brilliant Autumn's Glow
+,(40013, 3, 0) -- Smooth Autumn's Glow
+,(40014, 3, 0) -- Rigid Autumn's Glow
+,(40015, 3, 0) -- Thick Autumn's Glow
+,(40016, 3, 0) -- Mystic Autumn's Glow
+,(40017, 3, 0) -- Quick Autumn's Glow
+
+/* Inscription: Glyphs (Req level 80-70) */
+,(42404, 3, 0) -- Glyph of Mass Dispel
+,(42971, 3, 0) -- Glyph of Vigor
+,(44684, 3, 0) -- Glyph of Frostfire
+,(41529, 3, 0) -- Glyph of Fire Elemental Totem
+,(42748, 3, 0) -- Glyph of Invisibility
+,(42913, 3, 0) -- Glyph of Snake Trap
+,(40915, 3, 0) -- Glyph of Lifebloom
+,(41524, 3, 0) -- Glyph of Lava
+,(42745, 3, 0) -- Glyph of Ice Lance
 
 /* Inscription: Glyphs (Req level 70-30) */
 ,(41107, 1, 1) -- (1) Glyph of Avenging Wrath
@@ -730,12 +987,13 @@ VALUES
 ,(43395, 1, 1) -- Glyph of Battle
 ,(43418, 1, 1) -- Glyph of Heroic Strike
 
-/* Inscription: Scrolls + Vellums + Darkmoon cards */
-,(37093, 1, 0) -- Scroll of Stamina VII
-,(37091, 1, 0) -- Scroll of Intellect VII
-,(43463, 1, 0) -- Scroll of Agility VII
-,(37097, 1, 0) -- Scroll of Spirit VII
-,(43465, 1, 0) -- Scroll of Strength VII
+/* Inscription: Scrolls */
+,(49632, 1, 0) -- Runescroll of Fortitude
+,(43464, 1, 0) -- Scroll of Agility VIII
+,(37094, 1, 0) -- Scroll of Stamina VIII
+,(37092, 1, 0) -- Scroll of Intellect VIII
+,(43466, 1, 0) -- Scroll of Strength VIII
+,(37098, 1, 0) -- Scroll of Spirit VIII
 
 /* Enchanting: Things that have prices */
 ,(12655, 1, 0) -- Enchanted Thorium Bar
@@ -748,10 +1006,25 @@ VALUES
 ,(20750, 1, 1) -- Wizard Oil
 ,(20747, 1, 1) -- Lesser Mana Oil
 
-/* Tailoring (No gear) */
-,(24275, 1, 1) -- Silver Spellthread
-,(24273, 1, 1) -- Mystic Spellthread
 
+/* Tailoring (No gear) */
+,(41604, 1, 0) -- Sapphire Spellthread
+,(41602, 1, 0) -- Brilliant Spellthread
+,(41601, 1, 0) -- Shining Spellthread
+,(41603, 1, 0) -- Azure Spellthread
+,(24276, 1, 0) -- Golden Spellthread
+,(24274, 1, 0) -- Runic Spellthread
+,(24273, 1, 0) -- Mystic Spellthread
+,(24275, 1, 0) -- Silver Spellthread
+
+
+,(41600, 1, 0) -- Glacial Bag
+,(41599, 1, 0) -- Frostweave Bag
+,(41598, 1, 0) -- Mysterious Bag
+,(45773, 1, 0) -- Emerald Bag
+,(41597, 1, 0) -- Abyssal Bag
+,(38225, 1, 0) -- Mycah's Botanical Bag
+,(21872, 1, 0) -- Ebon Shadowbag
 ,(21876, 1, 0) -- Primal Mooncloth Bag
 ,(21843, 1, 0) -- Imbued Netherweave Bag
 ,(22252, 1, 0) -- Satchel of Cenarius
@@ -779,55 +1052,105 @@ VALUES
 ,(4238, 1, 0) -- Linen Bag
 
 /* Leatherworking (No gear) */
-,(34207, 1, 1) -- Glove Reinforcements
-,(34330, 1, 1) -- Heavy Knothide Armor Kit
-,(29485, 1, 1) -- Flame Armor Kit
-,(29488, 1, 1) -- Arcane Armor Kit
-,(29483, 1, 1) -- Shadow Armor Kit
-,(29487, 1, 1) -- Nature Armor Kit
-,(29486, 1, 1) -- Frost Armor Kit
-,(29533, 1, 1) -- Cobrahide Leg Armor
-,(29534, 1, 1) -- Clefthide Leg Armor
-,(25652, 1, 1) -- Magister's Armor Kit
-,(25651, 1, 1) -- Vindicator's Armor Kit
-,(18251, 1, 1) -- Core Armor Kit
-,(25679, 1, 1) -- Comfortable Insoles
-,(25650, 1, 1) -- Knothide Armor Kit
+,(44963, 1, 0) -- Earthen Leg Armor
+,(38373, 1, 0) -- Frosthide Leg Armor
+,(38374, 1, 0) -- Icescale Leg Armor
+,(38376, 1, 0) -- Heavy Borean Armor Kit
+,(38375, 1, 0) -- Borean Armor Kit
+,(38372, 1, 0) -- Nerubian Leg Armor
+,(38371, 1, 0) -- Jormungar Leg Armor
+,(29536, 1, 0) -- Nethercleft Leg Armor
+,(29535, 1, 0) -- Nethercobra Leg Armor
+,(34207, 1, 0) -- Glove Reinforcements
+,(34330, 1, 0) -- Heavy Knothide Armor Kit
+,(29485, 1, 0) -- Flame Armor Kit
+,(29488, 1, 0) -- Arcane Armor Kit
+,(29483, 1, 0) -- Shadow Armor Kit
+,(29487, 1, 0) -- Nature Armor Kit
+,(29486, 1, 0) -- Frost Armor Kit
+,(29533, 1, 0) -- Cobrahide Leg Armor
+,(29534, 1, 0) -- Clefthide Leg Armor
+,(25651, 1, 0) -- Vindicator's Armor Kit
+,(25652, 1, 0) -- Magister's Armor Kit
+,(18251, 1, 0) -- Core Armor Kit
+,(25650, 1, 0) -- Knothide Armor Kit
+,(15564, 1, 0) -- Rugged Armor Kit
+,(8173, 1, 0) -- Thick Armor Kit
+,(4265, 1, 0) -- Heavy Armor Kit
+,(2313, 1, 0) -- Medium Armor Kit
+,(2304, 1, 0) -- Light Armor Kit
 
+,(49634, 1, 0) -- Drums of the Wild
+,(49633, 1, 0) -- Drums of Forgotten Kings
+
+,(38399, 1, 0) -- Trapper's Traveling Pack
+,(44447, 1, 0) -- Dragonscale Ammo Pouch
+,(44446, 1, 0) -- Pack of Endless Pockets
+,(38347, 1, 0) -- Mammoth Mining Bag
+,(44448, 1, 0) -- Nerubian Reinforced Quiver
+,(34105, 1, 0) -- Quiver of a Thousand Feathers
 ,(34490, 1, 0) -- Bag of Many Hides
 ,(34106, 1, 0) -- Netherscale Ammo Pouch
-,(34105, 1, 0) -- Quiver of a Thousand Feathers
 ,(34100, 1, 0) -- Knothide Quiver
 ,(34099, 1, 0) -- Knothide Ammo Pouch
-,(34482, 1, 0) -- Leatherworker's Satchel
 ,(29540, 1, 0) -- Reinforced Mining Bag
+,(34482, 1, 0) -- Leatherworker's Satchel
 ,(8218, 1, 0) -- Thick Leather Ammo Pouch
 ,(8217, 1, 0) -- Quickdraw Quiver
-,(7372, 1, 0) -- Heavy Leather Ammo Pouch
 ,(7371, 1, 0) -- Heavy Quiver
+,(7372, 1, 0) -- Heavy Leather Ammo Pouch
 ,(5081, 1, 0) -- Kodo Hide Bag
-,(7278, 1, 0) -- Light Leather Quiver
 ,(7279, 1, 0) -- Small Leather Ammo Pouch
+,(7278, 1, 0) -- Light Leather Quiver
 
 /* Blacksmithing */
 ,(41745, 1, 0) -- Titanium Rod
 ,(25844, 1, 0) -- Adamantite Rod
 ,(25843, 1, 0) -- Fel Iron Rod
 
-,(23530, 1, 1) -- Felsteel Shield Spike
-,(23529, 1, 1) -- Adamantite Sharpening Stone
-,(28421, 1, 1) -- Adamantite Weightstone
-,(23576, 1, 1) -- Greater Ward of Shielding
-,(25521, 1, 1) -- Greater Rune of Warding
-,(23575, 1, 1) -- Lesser Ward of Shielding
-,(23559, 1, 1) -- Lesser Rune of Warding
-,(33185, 1, 1) -- Adamantite Weapon Chain
-,(18262, 1, 1) -- Elemental Sharpening Stone
-,(23528, 1, 1) -- Fel Sharpening Stone
-,(28420, 1, 1) -- Fel Weightstone
-,(7969, 1, 1) -- Mithril Spurs
+,(41611, 1, 0) -- Eternal Belt Buckle
+,(44936, 1, 0) -- Titanium Plating
+,(42500, 1, 0) -- Titanium Shield Spike
+,(41976, 1, 0) -- Titanium Weapon Chain
+,(23530, 1, 0) -- Felsteel Shield Spike
+,(28421, 1, 0) -- Adamantite Weightstone
+,(23529, 1, 0) -- Adamantite Sharpening Stone
+,(23576, 1, 0) -- Greater Ward of Shielding
+,(25521, 1, 0) -- Greater Rune of Warding
+,(23559, 1, 0) -- Lesser Rune of Warding
+,(23575, 1, 0) -- Lesser Ward of Shielding
+,(33185, 1, 0) -- Adamantite Weapon Chain
+,(18262, 1, 0) -- Elemental Sharpening Stone
+,(23528, 1, 0) -- Fel Sharpening Stone
+,(28420, 1, 0) -- Fel Weightstone
+,(12645, 1, 0) -- Thorium Shield Spike
+,(12643, 1, 0) -- Dense Weightstone
+,(12404, 1, 0) -- Dense Sharpening Stone
+,(7967, 1, 0) -- Mithril Shield Spike
+,(7969, 1, 0) -- Mithril Spurs
+,(6041, 1, 0) -- Steel Weapon Chain
+,(7965, 1, 0) -- Solid Weightstone
+,(7964, 1, 0) -- Solid Sharpening Stone
+,(6043, 1, 0) -- Iron Counterweight
+,(6042, 1, 0) -- Iron Shield Spike
+,(2871, 1, 0) -- Heavy Sharpening Stone
+,(3241, 1, 0) -- Heavy Weightstone
+,(3240, 1, 0) -- Coarse Weightstone
+,(2863, 1, 0) -- Coarse Sharpening Stone
+,(2862, 1, 0) -- Rough Sharpening Stone
+,(3239, 1, 0) -- Rough Weightstone
 
-/* Engineering: Useless junk? */
+/* Engineering */
+,(41167, 3, 0) -- Heartseeker Scope
+,(37567, 3, 0) -- Healing Injector Kit
+,(42546, 3, 0) -- Mana Injector Kit
+,(23766, 3, 0) -- Stabilized Eternium Scope
+,(23775, 3, 0) -- Titanium Toolbox
+,(41146, 3, 0) -- Sun Scope
+,(44739, 3, 0) -- Diamond-cut Refractor Scope
+,(23765, 3, 0) -- Khorium Scope
+,(40772, 3, 0) -- Gnomish Army Knife
+
 ,(20475, 1, 1) -- Adamantite Arrow Maker
 ,(34504, 1, 1) -- Adamantite Shell Machine
 ,(33093, 1, 0) -- Mana Potion Injector
@@ -882,7 +1205,55 @@ VALUES
 ,(21557, 1, 0) -- Small Red Rocket
 ,(23768, 1, 0) -- White Smoke Flare
 
-/* Cooking (50-70) */
+/* Cooking (50-80) */
+,(45932, 3, 0) -- Black Jelly
+,(39520, 3, 0) -- Kungaloosh
+,(42999, 3, 0) -- Blackened Dragonfin
+,(34762, 3, 0) -- Grilled Sculpin
+,(43492, 3, 0) -- Haunted Herring
+,(34769, 3, 0) -- Imperial Manta Steak
+,(34749, 3, 0) -- Shoveltusk Steak
+,(42995, 3, 0) -- Hearty Rhino
+,(34757, 3, 0) -- Very Burnt Worg
+,(34765, 3, 0) -- Pickled Fangtooth
+,(43268, 3, 0) -- Dalaran Clam Chowder
+,(34752, 3, 0) -- Rhino Dogs
+,(34747, 3, 0) -- Northern Stew
+,(42998, 3, 0) -- Cuttlesteak
+,(34760, 3, 0) -- Grilled Bonescale
+,(43491, 3, 0) -- Bad Clams
+,(42942, 3, 0) -- Baked Manta Ray
+,(34748, 3, 0) -- Mammoth Meal
+,(43004, 3, 0) -- Critter Bites
+,(34756, 3, 0) -- Spiced Worm Burger
+,(34764, 3, 0) -- Poached Nettlefish
+,(43001, 3, 0) -- Tracker Snacks
+,(34751, 3, 0) -- Roasted Worg
+,(42997, 3, 0) -- Blackened Worg Steak
+,(34759, 3, 0) -- Smoked Rockfin
+,(43488, 3, 0) -- Last Weeks Mammoth
+,(34767, 3, 0) -- Firecracker Salmon
+,(42994, 3, 0) -- Rhinolicious Wormsteak
+,(34755, 3, 0) -- Tender Shoveltusk Steak
+,(43000, 3, 0) -- Dragonfin Filet
+,(34763, 3, 0) -- Smoked Salmon
+,(44953, 3, 0) -- Worg Tartare
+,(34768, 3, 0) -- Spicy Blue Nettlefish
+,(34750, 3, 0) -- Worm Delight
+,(42996, 3, 0) -- Snapper Extreme
+,(34758, 3, 0) -- Mighty Rhino Dogs
+,(34766, 3, 0) -- Poached Northern Sculpin
+,(43490, 3, 0) -- Tasty Cupcake
+,(34754, 3, 0) -- Mega Mammoth Meal
+,(42993, 3, 0) -- Spicy Fried Herring
+,(43005, 3, 0) -- Spiced Mammoth Treats
+,(34761, 3, 0) -- Sauteed Goby
+,(33048, 3, 0) -- Stewed Trout
+,(33053, 3, 0) -- Hot Buttered Trout
+,(34411, 3, 0) -- Hot Apple Cider
+,(33052, 3, 0) -- Fisherman's Feast
+,(33872, 3, 0) -- Spicy Hot Talbuk
+
 ,(33825, 1, 0) -- Skullfish Soup
 ,(21023, 1, 0) -- Dirge's Kickin' Chimaerok Chops
 ,(27651, 1, 0) -- Buzzard Bites
@@ -915,20 +1286,13 @@ VALUES
 ,(35565, 1, 0) -- Juicy Bear Burger
 ,(46691, 1, 0) -- Bread of the Dead
 
-/* Eternal elemtents and crystallized elements (Northrend)*/
-
+/* Eternal elements (Northrend)*/
 ,(35622, 3, 0) -- Eternal Water
 ,(35623, 3, 0) -- Eternal Air
 ,(35624, 3, 0) -- Eternal Earth
 ,(35625, 3, 0) -- Eternal Life
 ,(35627, 3, 0) -- Eternal Shadow
 ,(36860, 3, 0) -- Eternal Fire
-,(37700, 3, 0) -- Crystallized Air
-,(37701, 3, 0) -- Crystallized Earth
-,(37702, 3, 0) -- Crystallized Fire
-,(37703, 3, 0) -- Crystallized Shadow
-,(37704, 3, 0) -- Crystallized Life
-,(37705, 3, 0) -- Cryystallized Water
 
 ;
 
@@ -954,16 +1318,104 @@ VALUES
 ,(22448, 3, 0, 60000)
 ,(22449, 1, 0, 80000)
 ,(22450, 1, 0, 200000) -- Endgame (70)
--- WOTLK ENCHANTING MATS --
-,(34054, 1, 0,  20000) -- Infinite Dust
-,(34056, 1, 0,  40000) -- Lesser Cosmic Essence
-,(34055, 1, 0,  120000) -- Greater Cosmic Essence
-,(34053, 1, 0,  70000) -- Small Dream Shard
+,(34054, 1, 0, 20000) -- Infinite Dust -- WoTLK
+,(34056, 1, 0, 40000) -- Lesser Cosmic Essence
+,(34055, 1, 0, 120000) -- Greater Cosmic Essence
+,(34053, 1, 0, 70000) -- Small Dream Shard
 ,(34052, 1, 0, 210000) -- Dream Shard
 ,(34057, 1, 0, 400000) -- Abyss Crystal
 
 /* Enchanting: Scrolls (none have a sell price) (70-50) */
-,(22459, 1, 1, 50000) -- (1) Void Sphere
+,(43987, 3, 0, 450000) -- Scroll of Enchant Weapon - Black Magic
+,(45056, 3, 0, 450000) -- Scroll of Enchant Staff - Greater Spellpower
+,(38972, 3, 0, 450000) -- Scroll of Enchant Weapon - Lifeward
+,(44467, 3, 0, 450000) -- Scroll of Enchant Weapon - Mighty Spellpower
+,(38991, 3, 0, 450000) -- Scroll of Enchant Weapon - Exceptional Spellpower
+,(38997, 3, 0, 300000) -- Scroll of Enchant Bracers - Greater Spellpower
+,(39004, 3, 0, 300000) -- Scroll of Enchant Cloak - Wisdom
+,(38990, 3, 0, 300000) -- Scroll of Enchant Gloves - Armsman
+,(38978, 3, 0, 300000) -- Scroll of Enchant Cloak - Titanweave
+,(38986, 3, 0, 300000) -- Scroll of Enchant Boots - Icewalker
+,(38993, 3, 0, 300000) -- Scroll of Enchant Cloak - Shadow Armor
+,(39003, 3, 0, 300000) -- Scroll of Enchant Cloak - Greater Speed
+,(38989, 3, 0, 300000) -- Scroll of Enchant Chest - Super Stats
+,(39006, 3, 0, 300000) -- Scroll of Enchant Boots - Tuskarr's Vitality
+,(44458, 3, 0, 300000) -- Scroll of Enchant Gloves - Crusher
+,(38967, 3, 0, 300000) -- Scroll of Enchant Gloves - Major Agility
+,(39005, 3, 0, 300000) -- Scroll of Enchant Chest - Super Health
+,(38979, 3, 0, 300000) -- Scroll of Enchant Gloves - Exceptional Spellpower
+,(38965, 3, 0, 450000) -- Scroll of Enchant Weapon - Icebreaker
+,(38995, 3, 0, 450000) -- Scroll of Enchant Weapon - Exceptional Agility
+,(38964, 3, 0, 300000) -- Scroll of Enchant Gloves - Greater Assault
+,(38984, 3, 0, 300000) -- Scroll of Enchant Bracer - Expertise
+,(38992, 3, 0, 450000) -- Scroll of Enchant 2H Weapon - Greater Savagery
+,(38988, 3, 0, 450000) -- Scroll of Enchant Weapon - Giant Slayer
+,(38975, 3, 0, 300000) -- Scroll of Enchant Chest - Exceptional Resilience
+,(38985, 3, 0, 300000) -- Scroll of Enchant Gloves - Greater Blasting
+,(38976, 3, 0, 300000) -- Scroll of Enchant Boots - Superior Agility
+,(44946, 3, 0, 450000) -- Scroll of Enchant Weapon - Titanguard
+,(45060, 3, 0, 450000) -- Scroll of Enchant Staff - Spellpower
+,(38981, 3, 0, 450000) -- Scroll of Enchant 2H Weapon - Scourgebane
+,(46098, 3, 0, 450000) -- Scroll of Enchant Weapon - Blood Draining
+,(38963, 3, 0, 450000) -- Scroll of Enchant Weapon - Exceptional Spirit
+,(46026, 3, 0, 450000) -- Scroll of Enchant Weapon - Blade Ward
+,(38982, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Arcane Resistance
+,(38969, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Fire Resistance
+,(38956, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Nature Resistance
+,(38950, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Frost Resistance
+,(38977, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Shadow Resistance
+,(38980, 3, 0, 300000) -- Scroll of Enchant Bracers - Major Spirit
+,(39002, 3, 0, 300000) -- Scroll of Enchant Chest - Greater Defense
+,(44947, 3, 0, 300000) -- Scroll of Enchant Bracer - Major Stamina
+,(38959, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Agility
+,(38987, 3, 0, 300000) -- Scroll of Enchant Bracers - Greater Stats
+,(44466, 3, 0, 450000) -- Scroll of Enchant Weapon - Superior Potency
+,(44463, 3, 0, 450000) -- Scroll of Enchant 2H Weapon - Massacre
+,(44493, 3, 0, 450000) -- Scroll of Enchant Weapon - Berserking
+,(38973, 3, 0, 300000) -- Scroll of Enchant Cloak - Spell Piercing
+,(38955, 3, 0, 300000) -- Scroll of Enchant Chest - Mighty Health
+,(44465, 3, 0, 300000) -- Scroll of Enchant Chest - Powerful Stats
+,(38953, 3, 0, 300000) -- Scroll of Enchant Gloves - Precision
+
+,(38924, 3, 0, 450000) -- Scroll of Enchant Weapon - Soulfrost
+,(38923, 3, 0, 450000) -- Scroll of Enchant Weapon - Sunfire
+,(38948, 3, 0, 450000) -- Scroll of Enchant Weapon - Executioner
+,(38925, 3, 0, 450000) -- Scroll of Enchant Weapon - Mongoose
+,(38962, 3, 0, 300000) -- Scroll of Enchant Chest - Greater Mana Restoration
+,(44456, 3, 0, 300000) -- Scroll of Enchant Cloak - Speed
+,(39000, 3, 0, 300000) -- Scroll of Enchant Cloak - Steelweave
+,(38968, 3, 0, 300000) -- Scroll of Enchant Bracers - Exceptional Intellect
+,(44455, 3, 0, 300000) -- Scroll of Enchant Shield - Greater Intellect
+,(38960, 3, 0, 300000) -- Scroll of Enchant Gloves - Gatherer
+,(44457, 3, 0, 300000) -- Scroll of Enchant Cloak - Major Agility
+,(38966, 3, 0, 300000) -- Scroll of Enchant Boots - Greater Fortitude
+,(38910, 3, 0, 300000) -- Scroll of Enchant Boots - Surefooted
+,(44497, 3, 0, 450000) -- Scroll of Enchant Weapon - Accuracy
+,(38998, 3, 0, 450000) -- Scroll of Enchant Weapon - Deathfrost
+,(38951, 3, 0, 300000) -- Scroll of Enchant Gloves - Expertise
+,(38974, 3, 0, 300000) -- Scroll of Enchant Boots - Greater Vitality
+,(38927, 3, 0, 450000) -- Scroll of Enchant Weapon - Battlemaster
+,(38926, 3, 0, 450000) -- Scroll of Enchant Weapon - Spellsurge
+,(38922, 3, 0, 450000) -- Scroll of Enchant 2H Weapon - Major Agility
+,(38932, 3, 0, 300000) -- Scroll of Enchant Gloves - Precise Strikes
+,(38907, 3, 0, 300000) -- Scroll of Enchant Shield - Resistance
+,(38944, 3, 0, 300000) -- Scroll of Enchant Boots - Boar's Speed
+,(38903, 3, 0, 300000) -- Scroll of Enchant Bracer - Spellpower
+,(38999, 3, 0, 300000) -- Scroll of Enchant Chest - Defense
+,(44469, 3, 0, 300000) -- Scroll of Enchant Boots - Greater Assault
+,(38943, 3, 0, 300000) -- Scroll of Enchant Boots - Cat's Swiftness
+,(38935, 3, 0, 300000) -- Scroll of Enchant Gloves - Major Spellpower
+,(44453, 3, 0, 450000) -- Scroll of Enchant Weapon - Greater Potency
+,(44470, 3, 0, 300000) -- Scroll of Enchant Bracer - Superior Spellpower
+,(38961, 3, 0, 300000) -- Scroll of Enchant Boots - Greater Spirit
+,(44815, 3, 0, 300000) -- Scroll of Enchant Bracers - Greater Assault
+,(38912, 3, 0, 300000) -- Scroll of Enchant Chest - Exceptional Mana
+,(38954, 3, 0, 300000) -- Scroll of Enchant Shield - Defense
+,(38971, 3, 0, 300000) -- Scroll of Enchant Bracers - Striking
+,(39001, 3, 0, 300000) -- Scroll of Enchant Cloak - Mighty Armor
+,(44449, 3, 0, 300000) -- Scroll of Enchant Boots - Assault
+
+,(22459, 1, 1, 50000) -- (Level 70) Void Sphere
 ,(38921, 1, 1, 150000) -- Scroll of Enchant Weapon - Major Spellpower
 ,(38946, 1, 1, 150000) -- Scroll of Enchant Weapon - Major Healing
 ,(22460, 1, 1, 10000) -- Prismatic Sphere
@@ -1013,7 +1465,7 @@ VALUES
 ,(38904, 1, 1, 100000) -- Scroll of Enchant Shield - Tough Shield
 ,(38940, 1, 1, 100000) -- Scroll of Enchant Cloak - Greater Agility
 
-,(38865, 1, 1, 100000) -- (51) Scroll of Enchant Chest - Greater Stats
+,(38865, 1, 1, 100000) -- Scroll of Enchant Chest - Greater Stats
 ,(38934, 1, 1, 100000) -- Scroll of Enchant Gloves - Assault
 ,(38914, 1, 1, 100000) -- Scroll of Enchant Cloak - Major Armor
 ,(38873, 1, 1, 150000) -- Scroll of Enchant Weapon - Crusader
@@ -1060,8 +1512,6 @@ VALUES
 ,(39350, 1, 0, 5000) -- Weapon Vellum II
 ,(38682, 1, 0, 1000) -- Armor Vellum
 ,(39349, 1, 0, 100) -- Weapon Vellum
-
--- ,(44317, 1, 0) -- Greater Darkmoon Card -- Not obtainable without crafting
 
 /* Engineering: Mounts that should be super expensive + need a custom price */
 ,(41508, 1, 0, 50000000) -- Mechano-hog

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -1326,94 +1326,94 @@ VALUES
 ,(34057, 1, 0, 400000) -- Abyss Crystal
 
 /* Enchanting: Scrolls (none have a sell price) (70-50) */
-,(43987, 3, 0, 450000) -- Scroll of Enchant Weapon - Black Magic
-,(45056, 3, 0, 450000) -- Scroll of Enchant Staff - Greater Spellpower
-,(38972, 3, 0, 450000) -- Scroll of Enchant Weapon - Lifeward
-,(44467, 3, 0, 450000) -- Scroll of Enchant Weapon - Mighty Spellpower
-,(38991, 3, 0, 450000) -- Scroll of Enchant Weapon - Exceptional Spellpower
-,(38997, 3, 0, 300000) -- Scroll of Enchant Bracers - Greater Spellpower
-,(39004, 3, 0, 300000) -- Scroll of Enchant Cloak - Wisdom
-,(38990, 3, 0, 300000) -- Scroll of Enchant Gloves - Armsman
-,(38978, 3, 0, 300000) -- Scroll of Enchant Cloak - Titanweave
-,(38986, 3, 0, 300000) -- Scroll of Enchant Boots - Icewalker
-,(38993, 3, 0, 300000) -- Scroll of Enchant Cloak - Shadow Armor
-,(39003, 3, 0, 300000) -- Scroll of Enchant Cloak - Greater Speed
-,(38989, 3, 0, 300000) -- Scroll of Enchant Chest - Super Stats
-,(39006, 3, 0, 300000) -- Scroll of Enchant Boots - Tuskarr's Vitality
-,(44458, 3, 0, 300000) -- Scroll of Enchant Gloves - Crusher
-,(38967, 3, 0, 300000) -- Scroll of Enchant Gloves - Major Agility
-,(39005, 3, 0, 300000) -- Scroll of Enchant Chest - Super Health
-,(38979, 3, 0, 300000) -- Scroll of Enchant Gloves - Exceptional Spellpower
-,(38965, 3, 0, 450000) -- Scroll of Enchant Weapon - Icebreaker
-,(38995, 3, 0, 450000) -- Scroll of Enchant Weapon - Exceptional Agility
-,(38964, 3, 0, 300000) -- Scroll of Enchant Gloves - Greater Assault
-,(38984, 3, 0, 300000) -- Scroll of Enchant Bracer - Expertise
-,(38992, 3, 0, 450000) -- Scroll of Enchant 2H Weapon - Greater Savagery
-,(38988, 3, 0, 450000) -- Scroll of Enchant Weapon - Giant Slayer
-,(38975, 3, 0, 300000) -- Scroll of Enchant Chest - Exceptional Resilience
-,(38985, 3, 0, 300000) -- Scroll of Enchant Gloves - Greater Blasting
-,(38976, 3, 0, 300000) -- Scroll of Enchant Boots - Superior Agility
-,(44946, 3, 0, 450000) -- Scroll of Enchant Weapon - Titanguard
-,(45060, 3, 0, 450000) -- Scroll of Enchant Staff - Spellpower
-,(38981, 3, 0, 450000) -- Scroll of Enchant 2H Weapon - Scourgebane
-,(46098, 3, 0, 450000) -- Scroll of Enchant Weapon - Blood Draining
-,(38963, 3, 0, 450000) -- Scroll of Enchant Weapon - Exceptional Spirit
-,(46026, 3, 0, 450000) -- Scroll of Enchant Weapon - Blade Ward
-,(38982, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Arcane Resistance
-,(38969, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Fire Resistance
-,(38956, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Nature Resistance
-,(38950, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Frost Resistance
-,(38977, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Shadow Resistance
-,(38980, 3, 0, 300000) -- Scroll of Enchant Bracers - Major Spirit
-,(39002, 3, 0, 300000) -- Scroll of Enchant Chest - Greater Defense
-,(44947, 3, 0, 300000) -- Scroll of Enchant Bracer - Major Stamina
-,(38959, 3, 0, 300000) -- Scroll of Enchant Cloak - Superior Agility
-,(38987, 3, 0, 300000) -- Scroll of Enchant Bracers - Greater Stats
-,(44466, 3, 0, 450000) -- Scroll of Enchant Weapon - Superior Potency
-,(44463, 3, 0, 450000) -- Scroll of Enchant 2H Weapon - Massacre
-,(44493, 3, 0, 450000) -- Scroll of Enchant Weapon - Berserking
-,(38973, 3, 0, 300000) -- Scroll of Enchant Cloak - Spell Piercing
-,(38955, 3, 0, 300000) -- Scroll of Enchant Chest - Mighty Health
-,(44465, 3, 0, 300000) -- Scroll of Enchant Chest - Powerful Stats
-,(38953, 3, 0, 300000) -- Scroll of Enchant Gloves - Precision
+,(43987, 1, 1, 450000) -- Scroll of Enchant Weapon - Black Magic
+,(45056, 1, 1, 450000) -- Scroll of Enchant Staff - Greater Spellpower
+,(38972, 1, 1, 450000) -- Scroll of Enchant Weapon - Lifeward
+,(44467, 1, 1, 450000) -- Scroll of Enchant Weapon - Mighty Spellpower
+,(38991, 1, 1, 450000) -- Scroll of Enchant Weapon - Exceptional Spellpower
+,(38997, 1, 1, 300000) -- Scroll of Enchant Bracers - Greater Spellpower
+,(39004, 1, 1, 300000) -- Scroll of Enchant Cloak - Wisdom
+,(38990, 1, 1, 300000) -- Scroll of Enchant Gloves - Armsman
+,(38978, 1, 1, 300000) -- Scroll of Enchant Cloak - Titanweave
+,(38986, 1, 1, 300000) -- Scroll of Enchant Boots - Icewalker
+,(38993, 1, 1, 300000) -- Scroll of Enchant Cloak - Shadow Armor
+,(39003, 1, 1, 300000) -- Scroll of Enchant Cloak - Greater Speed
+,(38989, 1, 1, 300000) -- Scroll of Enchant Chest - Super Stats
+,(39006, 1, 1, 300000) -- Scroll of Enchant Boots - Tuskarr's Vitality
+,(44458, 1, 1, 300000) -- Scroll of Enchant Gloves - Crusher
+,(38967, 1, 1, 300000) -- Scroll of Enchant Gloves - Major Agility
+,(39005, 1, 1, 300000) -- Scroll of Enchant Chest - Super Health
+,(38979, 1, 1, 300000) -- Scroll of Enchant Gloves - Exceptional Spellpower
+,(38965, 1, 1, 450000) -- Scroll of Enchant Weapon - Icebreaker
+,(38995, 1, 1, 450000) -- Scroll of Enchant Weapon - Exceptional Agility
+,(38964, 1, 1, 300000) -- Scroll of Enchant Gloves - Greater Assault
+,(38984, 1, 1, 300000) -- Scroll of Enchant Bracer - Expertise
+,(38992, 1, 1, 450000) -- Scroll of Enchant 2H Weapon - Greater Savagery
+,(38988, 1, 1, 450000) -- Scroll of Enchant Weapon - Giant Slayer
+,(38975, 1, 1, 300000) -- Scroll of Enchant Chest - Exceptional Resilience
+,(38985, 1, 1, 300000) -- Scroll of Enchant Gloves - Greater Blasting
+,(38976, 1, 1, 300000) -- Scroll of Enchant Boots - Superior Agility
+,(44946, 1, 1, 450000) -- Scroll of Enchant Weapon - Titanguard
+,(45060, 1, 1, 450000) -- Scroll of Enchant Staff - Spellpower
+,(38981, 1, 1, 450000) -- Scroll of Enchant 2H Weapon - Scourgebane
+,(46098, 1, 1, 450000) -- Scroll of Enchant Weapon - Blood Draining
+,(38963, 1, 1, 450000) -- Scroll of Enchant Weapon - Exceptional Spirit
+,(46026, 1, 1, 450000) -- Scroll of Enchant Weapon - Blade Ward
+,(38982, 1, 1, 300000) -- Scroll of Enchant Cloak - Superior Arcane Resistance
+,(38969, 1, 1, 300000) -- Scroll of Enchant Cloak - Superior Fire Resistance
+,(38956, 1, 1, 300000) -- Scroll of Enchant Cloak - Superior Nature Resistance
+,(38950, 1, 1, 300000) -- Scroll of Enchant Cloak - Superior Frost Resistance
+,(38977, 1, 1, 300000) -- Scroll of Enchant Cloak - Superior Shadow Resistance
+,(38980, 1, 1, 300000) -- Scroll of Enchant Bracers - Major Spirit
+,(39002, 1, 1, 300000) -- Scroll of Enchant Chest - Greater Defense
+,(44947, 1, 1, 300000) -- Scroll of Enchant Bracer - Major Stamina
+,(38959, 1, 1, 300000) -- Scroll of Enchant Cloak - Superior Agility
+,(38987, 1, 1, 300000) -- Scroll of Enchant Bracers - Greater Stats
+,(44466, 1, 1, 450000) -- Scroll of Enchant Weapon - Superior Potency
+,(44463, 1, 1, 450000) -- Scroll of Enchant 2H Weapon - Massacre
+,(44493, 1, 1, 450000) -- Scroll of Enchant Weapon - Berserking
+,(38973, 1, 1, 300000) -- Scroll of Enchant Cloak - Spell Piercing
+,(38955, 1, 1, 300000) -- Scroll of Enchant Chest - Mighty Health
+,(44465, 1, 1, 300000) -- Scroll of Enchant Chest - Powerful Stats
+,(38953, 1, 1, 300000) -- Scroll of Enchant Gloves - Precision
 
-,(38924, 3, 0, 450000) -- Scroll of Enchant Weapon - Soulfrost
-,(38923, 3, 0, 450000) -- Scroll of Enchant Weapon - Sunfire
-,(38948, 3, 0, 450000) -- Scroll of Enchant Weapon - Executioner
-,(38925, 3, 0, 450000) -- Scroll of Enchant Weapon - Mongoose
-,(38962, 3, 0, 300000) -- Scroll of Enchant Chest - Greater Mana Restoration
-,(44456, 3, 0, 300000) -- Scroll of Enchant Cloak - Speed
-,(39000, 3, 0, 300000) -- Scroll of Enchant Cloak - Steelweave
-,(38968, 3, 0, 300000) -- Scroll of Enchant Bracers - Exceptional Intellect
-,(44455, 3, 0, 300000) -- Scroll of Enchant Shield - Greater Intellect
-,(38960, 3, 0, 300000) -- Scroll of Enchant Gloves - Gatherer
-,(44457, 3, 0, 300000) -- Scroll of Enchant Cloak - Major Agility
-,(38966, 3, 0, 300000) -- Scroll of Enchant Boots - Greater Fortitude
-,(38910, 3, 0, 300000) -- Scroll of Enchant Boots - Surefooted
-,(44497, 3, 0, 450000) -- Scroll of Enchant Weapon - Accuracy
-,(38998, 3, 0, 450000) -- Scroll of Enchant Weapon - Deathfrost
-,(38951, 3, 0, 300000) -- Scroll of Enchant Gloves - Expertise
-,(38974, 3, 0, 300000) -- Scroll of Enchant Boots - Greater Vitality
-,(38927, 3, 0, 450000) -- Scroll of Enchant Weapon - Battlemaster
-,(38926, 3, 0, 450000) -- Scroll of Enchant Weapon - Spellsurge
-,(38922, 3, 0, 450000) -- Scroll of Enchant 2H Weapon - Major Agility
-,(38932, 3, 0, 300000) -- Scroll of Enchant Gloves - Precise Strikes
-,(38907, 3, 0, 300000) -- Scroll of Enchant Shield - Resistance
-,(38944, 3, 0, 300000) -- Scroll of Enchant Boots - Boar's Speed
-,(38903, 3, 0, 300000) -- Scroll of Enchant Bracer - Spellpower
-,(38999, 3, 0, 300000) -- Scroll of Enchant Chest - Defense
-,(44469, 3, 0, 300000) -- Scroll of Enchant Boots - Greater Assault
-,(38943, 3, 0, 300000) -- Scroll of Enchant Boots - Cat's Swiftness
-,(38935, 3, 0, 300000) -- Scroll of Enchant Gloves - Major Spellpower
-,(44453, 3, 0, 450000) -- Scroll of Enchant Weapon - Greater Potency
-,(44470, 3, 0, 300000) -- Scroll of Enchant Bracer - Superior Spellpower
-,(38961, 3, 0, 300000) -- Scroll of Enchant Boots - Greater Spirit
-,(44815, 3, 0, 300000) -- Scroll of Enchant Bracers - Greater Assault
-,(38912, 3, 0, 300000) -- Scroll of Enchant Chest - Exceptional Mana
-,(38954, 3, 0, 300000) -- Scroll of Enchant Shield - Defense
-,(38971, 3, 0, 300000) -- Scroll of Enchant Bracers - Striking
-,(39001, 3, 0, 300000) -- Scroll of Enchant Cloak - Mighty Armor
-,(44449, 3, 0, 300000) -- Scroll of Enchant Boots - Assault
+,(38924, 1, 1, 450000) -- Scroll of Enchant Weapon - Soulfrost
+,(38923, 1, 1, 450000) -- Scroll of Enchant Weapon - Sunfire
+,(38948, 1, 1, 450000) -- Scroll of Enchant Weapon - Executioner
+,(38925, 1, 1, 450000) -- Scroll of Enchant Weapon - Mongoose
+,(38962, 1, 1, 300000) -- Scroll of Enchant Chest - Greater Mana Restoration
+,(44456, 1, 1, 300000) -- Scroll of Enchant Cloak - Speed
+,(39000, 1, 1, 300000) -- Scroll of Enchant Cloak - Steelweave
+,(38968, 1, 1, 300000) -- Scroll of Enchant Bracers - Exceptional Intellect
+,(44455, 1, 1, 300000) -- Scroll of Enchant Shield - Greater Intellect
+,(38960, 1, 1, 300000) -- Scroll of Enchant Gloves - Gatherer
+,(44457, 1, 1, 300000) -- Scroll of Enchant Cloak - Major Agility
+,(38966, 1, 1, 300000) -- Scroll of Enchant Boots - Greater Fortitude
+,(38910, 1, 1, 300000) -- Scroll of Enchant Boots - Surefooted
+,(44497, 1, 1, 450000) -- Scroll of Enchant Weapon - Accuracy
+,(38998, 1, 1, 450000) -- Scroll of Enchant Weapon - Deathfrost
+,(38951, 1, 1, 300000) -- Scroll of Enchant Gloves - Expertise
+,(38974, 1, 1, 300000) -- Scroll of Enchant Boots - Greater Vitality
+,(38927, 1, 1, 450000) -- Scroll of Enchant Weapon - Battlemaster
+,(38926, 1, 1, 450000) -- Scroll of Enchant Weapon - Spellsurge
+,(38922, 1, 1, 450000) -- Scroll of Enchant 2H Weapon - Major Agility
+,(38932, 1, 1, 300000) -- Scroll of Enchant Gloves - Precise Strikes
+,(38907, 1, 1, 300000) -- Scroll of Enchant Shield - Resistance
+,(38944, 1, 1, 300000) -- Scroll of Enchant Boots - Boar's Speed
+,(38903, 1, 1, 300000) -- Scroll of Enchant Bracer - Spellpower
+,(38999, 1, 1, 300000) -- Scroll of Enchant Chest - Defense
+,(44469, 1, 1, 300000) -- Scroll of Enchant Boots - Greater Assault
+,(38943, 1, 1, 300000) -- Scroll of Enchant Boots - Cat's Swiftness
+,(38935, 1, 1, 300000) -- Scroll of Enchant Gloves - Major Spellpower
+,(44453, 1, 1, 450000) -- Scroll of Enchant Weapon - Greater Potency
+,(44470, 1, 1, 300000) -- Scroll of Enchant Bracer - Superior Spellpower
+,(38961, 1, 1, 300000) -- Scroll of Enchant Boots - Greater Spirit
+,(44815, 1, 1, 300000) -- Scroll of Enchant Bracers - Greater Assault
+,(38912, 1, 1, 300000) -- Scroll of Enchant Chest - Exceptional Mana
+,(38954, 1, 1, 300000) -- Scroll of Enchant Shield - Defense
+,(38971, 1, 1, 300000) -- Scroll of Enchant Bracers - Striking
+,(39001, 1, 1, 300000) -- Scroll of Enchant Cloak - Mighty Armor
+,(44449, 1, 1, 300000) -- Scroll of Enchant Boots - Assault
 
 ,(22459, 1, 1, 50000) -- (Level 70) Void Sphere
 ,(38921, 1, 1, 150000) -- Scroll of Enchant Weapon - Major Spellpower

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -849,6 +849,39 @@ VALUES
 ,(21557, 1, 0) -- Small Red Rocket
 ,(23768, 1, 0) -- White Smoke Flare
 
+/* Cooking (50-70) */
+,(33825, 1, 0) -- Skullfish Soup
+,(21023, 1, 0) -- Dirge's Kickin' Chimaerok Chops
+,(27651, 1, 0) -- Buzzard Bites
+,(27655, 1, 0) -- Ravager Dog
+,(27656, 1, 0) -- Sporeling Snack
+,(27657, 1, 0) -- Blackened Basilisk
+,(27658, 1, 0) -- Roasted Clefthoof
+,(27659, 1, 0) -- Warp Burger
+,(27660, 1, 0) -- Talbuk Steak
+,(27661, 1, 0) -- Blackened Trout
+,(27662, 1, 0) -- Feltail Delight
+,(27663, 1, 0) -- Blackened Sporefish
+,(27664, 1, 0) -- Grilled Mudfish
+,(27665, 1, 0) -- Poached Bluefish
+,(27666, 1, 0) -- Golden Fish Sticks
+,(27667, 1, 0) -- Spicy Crawdad
+,(30155, 1, 0) -- Clam Bar
+,(31672, 1, 0) -- Mok'Nathal Shortribs
+,(31673, 1, 0) -- Crunchy Serpent
+,(33866, 1, 0) -- Stormchops
+,(33867, 1, 0) -- Broiled Bloodfin
+,(33874, 1, 0) -- Kibler's Bits
+,(44838, 1, 0) -- Slow-Roasted Turkey
+,(13933, 1, 0) -- Lobster Stew
+,(13934, 1, 0) -- Mightfish Steak
+,(13935, 1, 0) -- Baked Salmon
+,(18254, 1, 0) -- Runn Tum Tuber Surprise
+,(20452, 1, 0) -- Smoked Desert Dumplings
+,(35563, 1, 0) -- Charred Bear Kabobs
+,(35565, 1, 0) -- Juicy Bear Burger
+,(46691, 1, 0) -- Bread of the Dead
+
 ;
 
 /****** All items that have no vendor price + thus need an explicitly specified sell price ******/

--- a/sql/world/base/add_default_simpleitemconfig.sql
+++ b/sql/world/base/add_default_simpleitemconfig.sql
@@ -5,6 +5,12 @@ VALUES
 /* Commonly sold drops */
 (30183, 3, 0) -- Nether Vortex
 ,(33470, 3, 0) -- Frostweave Cloth
+,(43102, 3, 1) -- Frozen Orb
+,(2589, 3, 0) -- Linen Cloth
+,(2592, 3, 0) -- Wool Cloth
+,(4338, 1, 0) -- Mageweave Cloth
+,(14047, 1, 0) -- Runecloth
+
 
 /* Herbalism: Gathered (0-80) */
 ,(36908, 1, 0) -- Frost Lotus

--- a/sql/world/base/mod_auctionhousebot.sql
+++ b/sql/world/base/mod_auctionhousebot.sql
@@ -367,7 +367,7 @@ VALUES
 (50289), (50301), (50307), (52189), (52202), (52272), (52275), (52276), (52345), (52562), (52563), (52565), (52729), (53510), (54218), (54455),
 (54467), (50248), (50431), (52011), (52062), (54291), (54470);
 
-DROP TABLE IF EXISTS `mod_auctionhousebot_simpleitemconfig`
+DROP TABLE IF EXISTS `mod_auctionhousebot_simpleitemconfig`;
 CREATE TABLE `mod_auctionhousebot_simpleitemconfig` (
   `itemID` int(11) DEFAULT '0' COMMENT 'The id of the item to insert. Must be a valid item id in the world.item_template table.',
   `numStacks` int(11) DEFAULT '0' COMMENT 'The number of stacks of this item that should be on the auction house.',

--- a/sql/world/base/mod_auctionhousebot.sql
+++ b/sql/world/base/mod_auctionhousebot.sql
@@ -370,5 +370,7 @@ VALUES
 DROP TABLE IF EXISTS `mod_auctionhousebot_simpleitemconfig`;
 CREATE TABLE `mod_auctionhousebot_simpleitemconfig` (
   `itemID` int(11) DEFAULT '0' COMMENT 'The id of the item to insert. Must be a valid item id in the world.item_template table.',
-  `numStacks` int(11) DEFAULT '0' COMMENT 'The number of stacks of this item that should be on the auction house.'
+  `numStacks` int(11) DEFAULT '0' COMMENT 'The number of stacks of this item that should be on the auction house.',
+  `sellPrice` int(11) DEFAULT '0' COMMENT 'The price, *in copper*, *per item* to sell the item for. If this is set to null or 0, auction house bot will decide automatically.',
+  PRIMARY KEY (`itemID`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/sql/world/base/mod_auctionhousebot.sql
+++ b/sql/world/base/mod_auctionhousebot.sql
@@ -371,6 +371,7 @@ DROP TABLE IF EXISTS `mod_auctionhousebot_simpleitemconfig`;
 CREATE TABLE `mod_auctionhousebot_simpleitemconfig` (
   `itemID` int(11) DEFAULT '0' COMMENT 'The id of the item to insert. Must be a valid item id in the world.item_template table.',
   `numStacks` int(11) DEFAULT '0' COMMENT 'The number of stacks of this item that should be on the auction house.',
-  `sellPrice` int(11) DEFAULT '0' COMMENT 'The price, *in copper*, *per item* to sell the item for. If this is set to null or 0, auction house bot will decide automatically.',
+  `stackSize` int(11) DEFAULT '0' COMMENT 'Optional. The number of items to include in each stack. If this is set to null or 0, stack size will be chosen automatically based on rarity and max item stack size',
+  `sellPrice` int(11) DEFAULT '0' COMMENT 'Optional. The price, *in copper*, *per item* to sell the item for. If this is set to null or 0, sell prices will be chosen automatically based on vendor prices.',
   PRIMARY KEY (`itemID`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/sql/world/base/mod_auctionhousebot.sql
+++ b/sql/world/base/mod_auctionhousebot.sql
@@ -370,5 +370,5 @@ VALUES
 DROP TABLE IF EXISTS `mod_auctionhousebot_simpleitemconfig`;
 CREATE TABLE `mod_auctionhousebot_simpleitemconfig` (
   `itemID` int(11) DEFAULT '0' COMMENT 'The id of the item to insert. Must be a valid item id in the world.item_template table.',
-  `numStacks` int(11) DEFAULT '0' COMMENT 'The number of stacks of this item that should be on the auction house.',
-)
+  `numStacks` int(11) DEFAULT '0' COMMENT 'The number of stacks of this item that should be on the auction house.'
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/sql/world/base/mod_auctionhousebot.sql
+++ b/sql/world/base/mod_auctionhousebot.sql
@@ -366,3 +366,9 @@ VALUES
 (53890), (54069), (54860), (50840), (53891), (53924), (51997), (51998), (54847), (54857), (56806), (54212), (54452), (54810), (50093), (54822),
 (50289), (50301), (50307), (52189), (52202), (52272), (52275), (52276), (52345), (52562), (52563), (52565), (52729), (53510), (54218), (54455),
 (54467), (50248), (50431), (52011), (52062), (54291), (54470);
+
+DROP TABLE IF EXISTS `mod_auctionhousebot_simpleitemconfig`
+CREATE TABLE `mod_auctionhousebot_simpleitemconfig` (
+  `itemID` int(11) DEFAULT '0' COMMENT 'The id of the item to insert. Must be a valid item id in the world.item_template table.',
+  `numStacks` int(11) DEFAULT '0' COMMENT 'The number of stacks of this item that should be on the auction house.',
+)

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -402,7 +402,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
 
             uint32 dep =  sAuctionMgr->GetAuctionDeposit(ahEntry, etime, item, stackCount);
 
-            SQLTransaction trans = CharacterDatabase.BeginTransaction();
+            auto trans = CharacterDatabase.BeginTransaction();
             AuctionEntry* auctionEntry = new AuctionEntry();
             auctionEntry->Id = sObjectMgr->GenerateAuctionID();
             auctionEntry->houseId = config->GetAHID();
@@ -642,8 +642,8 @@ void AuctionHouseBot::addNewAuctionBuyerBotBid(Player *AHBplayer, AHBConfig *con
                 else
                 {
                     // mail to last bidder and return money
-                    SQLTransaction trans = CharacterDatabase.BeginTransaction();
-                    sAuctionMgr->SendAuctionOutbiddedMail(auction , bidprice, session->GetPlayer(), trans);
+                    auto trans = CharacterDatabase.BeginTransaction();
+                    sAuctionMgr->SendAuctionOutbiddedMail(auction, bidprice, session->GetPlayer(), trans);
                     CharacterDatabase.CommitTransaction(trans);
                     //pl->ModifyMoney(-int32(price));
                 }
@@ -657,7 +657,7 @@ void AuctionHouseBot::addNewAuctionBuyerBotBid(Player *AHBplayer, AHBConfig *con
         }
         else
         {
-            SQLTransaction trans = CharacterDatabase.BeginTransaction();
+            auto trans = CharacterDatabase.BeginTransaction();
             //buyout
             if ((auction->bidder) && (AHBplayer->GetGUID() != auction->bidder))
             {
@@ -670,7 +670,7 @@ void AuctionHouseBot::addNewAuctionBuyerBotBid(Player *AHBplayer, AHBConfig *con
             //sAuctionMgr->SendAuctionSalePendingMail(auction, trans);
             sAuctionMgr->SendAuctionSuccessfulMail(auction, trans);
             sAuctionMgr->SendAuctionWonMail(auction, trans);
-            auction->DeleteFromDB( trans);
+            auction->DeleteFromDB(trans);
 
 			sAuctionMgr->RemoveAItem(auction->item_guid);
             auctionHouse->RemoveAuction(auction);
@@ -1555,7 +1555,7 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
             uint32 orangei = (uint32) strtoul(param13, NULL, 0);
             uint32 yellowi = (uint32) strtoul(param14, NULL, 0);
 
-			SQLTransaction trans = WorldDatabase.BeginTransaction();
+			auto trans = WorldDatabase.BeginTransaction();
             trans->PAppend("UPDATE mod_auctionhousebot SET percentgreytradegoods = '%u' WHERE auctionhouse = '%u'", greytg, ahMapID);
             trans->PAppend("UPDATE mod_auctionhousebot SET percentwhitetradegoods = '%u' WHERE auctionhouse = '%u'", whitetg, ahMapID);
             trans->PAppend("UPDATE mod_auctionhousebot SET percentgreentradegoods = '%u' WHERE auctionhouse = '%u'", greentg, ahMapID);

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -153,13 +153,13 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
 
     if (auctions >= minItems)
     {
-        //if (debug_Out) sLog->outError( "AHSeller: Auctions above minimum");
+        if (debug_Out) sLog->outError( "AHSeller: Auctions above minimum");
         return;
     }
 
     if (auctions >= maxItems)
     {
-        //if (debug_Out) sLog->outError( "AHSeller: Auctions at or above maximum");
+        if (debug_Out) sLog->outError( "AHSeller: Auctions at or above maximum");
         return;
     }
 

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1199,32 +1199,32 @@ void AuctionHouseBot::Initialize()
             }
 
             // Disable Items that require skill lower than X
-            // if ((DisableItemsBelowReqSkillRank) && (itr->second.RequiredSkillRank < DisableItemsBelowReqSkillRank))
-            // {
-            //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
-            //    continue;
-            // }
+            if ((DisableItemsBelowReqSkillRank) && (itr->second.RequiredSkillRank < DisableItemsBelowReqSkillRank))
+            {
+                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
+                continue;
+            }
 
             // Disable Items that require skill higher than X
-            // if ((DisableItemsAboveReqSkillRank) && (itr->second.RequiredSkillRank > DisableItemsAboveReqSkillRank))
-            // {
-            //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
-            //    continue;
-            // }
+            if ((DisableItemsAboveReqSkillRank) && (itr->second.RequiredSkillRank > DisableItemsAboveReqSkillRank))
+            {
+                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
+                continue;
+            }
 
             // Disable Trade Goods that require skill lower than X
-            // if ((DisableTGsBelowReqSkillRank) && (itr->second.RequiredSkillRank < DisableTGsBelowReqSkillRank))
-            // {
-            //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
-            //    continue;
-            // }
+            if ((DisableTGsBelowReqSkillRank) && (itr->second.RequiredSkillRank < DisableTGsBelowReqSkillRank))
+            {
+                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
+                continue;
+            }
 
             // Disable Trade Goods that require skill higher than X
-            // if ((DisableTGsAboveReqSkillRank) && (itr->second.?RequiredSkillRank > DisableTGsAboveReqSkillRank))
-            // {
-            //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
-            //    continue;
-            // }
+            if ((DisableTGsAboveReqSkillRank) && (itr->second.RequiredSkillRank > DisableTGsAboveReqSkillRank))
+            {
+                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
+                continue;
+            }
 
             switch (itr->second.Quality)
             {

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1746,6 +1746,10 @@ void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char*
 void AuctionHouseBot::LoadSimpleItemConfig()
 {
     if (debug_Out) sLog->outError( "AuctionHouseBot:LoadSimpleItemConfig starting");
+    if (simpleItemConfig.size() != 0) {
+        if (debug_Out) sLog->outError("AuctionHouseBot: Simple item config loaded multiple times. Previous size: %u", simpleItemConfig.size());
+        simpleItemConfig.clear();
+    }
     QueryResult results = QueryResult(NULL);
     char simpleItemQuery[] = "SELECT itemID, numStacks FROM mod_auctionhousebot_simpleitemconfig";
     results = WorldDatabase.Query(simpleItemQuery);

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1419,7 +1419,7 @@ void AuctionHouseBot::IncrementItemCounts(AuctionEntry* ah)
     Item *pItem =  sAuctionMgr->GetAItem(ah->item_guidlow);
     if (!pItem)
     {
-		if (debug_Out) sLog->outError( "AHBot: Item %u doesn't exist, perhaps bought already?", ah->item_guidlow);
+		if (debug_Out) sLog->outError( "AHBot:IncrementItemCounts Item %u doesn't exist, perhaps bought already?", ah->item_guidlow);
         return;
     }
 
@@ -1431,22 +1431,22 @@ void AuctionHouseBot::IncrementItemCounts(AuctionEntry* ah)
     FactionTemplateEntry const* u_entry = sFactionTemplateStore.LookupEntry(ah->GetHouseFaction());
     if (!u_entry)
     {
-        if (debug_Out) sLog->outError( "AHBot: %u returned as House Faction. Neutral", ah->GetHouseFaction());
+        if (debug_Out) sLog->outError( "AHBot:IncrementItemCounts %u returned as House Faction. Neutral", ah->GetHouseFaction());
         config = &NeutralConfig;
     }
     else if (u_entry->ourMask & FACTION_MASK_ALLIANCE)
     {
-        if (debug_Out) sLog->outError( "AHBot: %u returned as House Faction. Alliance", ah->GetHouseFaction());
+        if (debug_Out) sLog->outError( "AHBot:IncrementItemCounts %u returned as House Faction. Alliance", ah->GetHouseFaction());
         config = &AllianceConfig;
     }
     else if (u_entry->ourMask & FACTION_MASK_HORDE)
     {
-        if (debug_Out) sLog->outError( "AHBot: %u returned as House Faction. Horde", ah->GetHouseFaction());
+        if (debug_Out) sLog->outError( "AHBot:IncrementItemCounts %u returned as House Faction. Horde", ah->GetHouseFaction());
         config = &HordeConfig;
     }
     else
     {
-        if (debug_Out) sLog->outError( "AHBot: %u returned as House Faction. Neutral", ah->GetHouseFaction());
+        if (debug_Out) sLog->outError( "AHBot:IncrementItemCounts %u returned as House Faction. Neutral", ah->GetHouseFaction());
         config = &NeutralConfig;
     }
 
@@ -1463,22 +1463,22 @@ void AuctionHouseBot::DecrementItemCounts(AuctionEntry* ah, uint32 itemEntry)
     FactionTemplateEntry const* u_entry = sFactionTemplateStore.LookupEntry(ah->GetHouseFaction());
     if (!u_entry)
     {
-        if (debug_Out) sLog->outError( "AHBot: %u returned as House Faction. Neutral", ah->GetHouseFaction());
+        if (debug_Out) sLog->outError( "AHBot:DecrementItemCounts %u returned as House Faction. Neutral", ah->GetHouseFaction());
         config = &NeutralConfig;
     }
     else if (u_entry->ourMask & FACTION_MASK_ALLIANCE)
     {
-        if (debug_Out) sLog->outError( "AHBot: %u returned as House Faction. Alliance", ah->GetHouseFaction());
+        if (debug_Out) sLog->outError( "AHBot:DecrementItemCounts %u returned as House Faction. Alliance", ah->GetHouseFaction());
         config = &AllianceConfig;
     }
     else if (u_entry->ourMask & FACTION_MASK_HORDE)
     {
-        if (debug_Out) sLog->outError( "AHBot: %u returned as House Faction. Horde", ah->GetHouseFaction());
+        if (debug_Out) sLog->outError( "AHBot:DecrementItemCounts %u returned as House Faction. Horde", ah->GetHouseFaction());
         config = &HordeConfig;
     }
     else
     {
-        if (debug_Out) sLog->outError( "AHBot: %u returned as House Faction. Neutral", ah->GetHouseFaction());
+        if (debug_Out) sLog->outError( "AHBot:DecrementItemCounts %u returned as House Faction. Neutral", ah->GetHouseFaction());
         config = &NeutralConfig;
     }
 

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -383,9 +383,9 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
             if (prototype->Quality <= AHB_MAX_QUALITY)
             {
                 if (config->GetMaxStack(prototype->Quality) > 1 && item->GetMaxStackCount() > 1)
-                    stackCount = urand(1, minValue(item->GetMaxStackCount(), config->GetMaxStack(prototype->Quality)));
+                    stackCount = minValue(item->GetMaxStackCount(), config->GetMaxStack(prototype->Quality));
                 else if (config->GetMaxStack(prototype->Quality) == 0 && item->GetMaxStackCount() > 1)
-                    stackCount = urand(1, item->GetMaxStackCount());
+                    stackCount = item->GetMaxStackCount();
                 else
                     stackCount = 1;
                 buyoutPrice *= urand(config->GetMinPrice(prototype->Quality), config->GetMaxPrice(prototype->Quality));

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -48,6 +48,7 @@ AuctionHouseBot::AuctionHouseBot()
     debug_Out = false;
     debug_Out_Filters = false;
     AHBSeller = false;
+    SimpleSellerMode = false;
     AHBBuyer = false;
 
     //Begin Filters
@@ -1348,6 +1349,7 @@ void AuctionHouseBot::InitializeConfiguration()
     debug_Out_Filters = sConfigMgr->GetBoolDefault("AuctionHouseBot.DEBUG_FILTERS", false);
 
     AHBSeller = sConfigMgr->GetBoolDefault("AuctionHouseBot.EnableSeller", false);
+    SimpleSellerMode = sConfigMgr->GetBoolDefault("AuctionHouseBot.SimpleSellerMode", false);
     AHBBuyer = sConfigMgr->GetBoolDefault("AuctionHouseBot.EnableBuyer", false);
     SellMethod = sConfigMgr->GetBoolDefault("AuctionHouseBot.UseBuyPriceForSeller", false);
     BuyMethod = sConfigMgr->GetBoolDefault("AuctionHouseBot.UseBuyPriceForBuyer", false);

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -227,7 +227,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
     uint32 purpleItems = config->GetItemCounts(AHB_PURPLE_I);
     uint32 orangeItems = config->GetItemCounts(AHB_ORANGE_I);
     uint32 yellowItems = config->GetItemCounts(AHB_YELLOW_I);
-    if (debug_Out) sLog->outError( "AHSeller: %u items", items);
+    if (debug_Out) sLog->outError( "AHSeller: Will try to find %u items to add", items);
 
     // If simple seller mode, decide what items to insert this cycle
     vector<uint32> simpleMode_ItemsToInsert;
@@ -254,7 +254,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
     // only insert a few at a time, so as not to peg the processor
     for (uint32 cnt = 1; cnt <= items || (SimpleSellerMode && (cnt - 1) < simpleMode_ItemsToInsert.size()); cnt++)
     {
-    if (debug_Out) sLog->outError( "AHSeller: %u count", cnt);
+        if (debug_Out) sLog->outError( "AHSeller: %u count", cnt);
         uint32 itemID = 0;
         uint32 itemColor = 99;
         uint32 loopbreaker = 0;
@@ -276,115 +276,115 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
             }
             else 
             {
-            ++loopbreaker;
-            uint32 choice = urand(0, 13);
-            itemColor = choice;
-            switch (choice)
-            {
-            case 0:
+                ++loopbreaker;
+                uint32 choice = urand(0, 13);
+                itemColor = choice;
+                switch (choice)
                 {
-                    if ((greyItemsBin.size() > 0) && (greyItems < greyIcount))
-                        itemID = greyItemsBin[urand(0, greyItemsBin.size() - 1)];
-                    else continue;
-                    break;
+                case 0:
+                    {
+                        if ((greyItemsBin.size() > 0) && (greyItems < greyIcount))
+                            itemID = greyItemsBin[urand(0, greyItemsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 1:
+                    {
+                        if ((whiteItemsBin.size() > 0) && (whiteItems < whiteIcount))
+                            itemID = whiteItemsBin[urand(0, whiteItemsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 2:
+                    {
+                        if ((greenItemsBin.size() > 0) && (greenItems < greenIcount))
+                            itemID = greenItemsBin[urand(0, greenItemsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 3:
+                    {
+                        if ((blueItemsBin.size() > 0) && (blueItems < blueIcount))
+                            itemID = blueItemsBin[urand(0, blueItemsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 4:
+                    {
+                        if ((purpleItemsBin.size() > 0) && (purpleItems < purpleIcount))
+                            itemID = purpleItemsBin[urand(0, purpleItemsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 5:
+                    {
+                        if ((orangeItemsBin.size() > 0) && (orangeItems < orangeIcount))
+                            itemID = orangeItemsBin[urand(0, orangeItemsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 6:
+                    {
+                        if ((yellowItemsBin.size() > 0) && (yellowItems < yellowIcount))
+                            itemID = yellowItemsBin[urand(0, yellowItemsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 7:
+                    {
+                        if ((greyTradeGoodsBin.size() > 0) && (greyTGoods < greyTGcount))
+                            itemID = greyTradeGoodsBin[urand(0, greyTradeGoodsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 8:
+                    {
+                        if ((whiteTradeGoodsBin.size() > 0) && (whiteTGoods < whiteTGcount))
+                            itemID = whiteTradeGoodsBin[urand(0, whiteTradeGoodsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 9:
+                    {
+                        if ((greenTradeGoodsBin.size() > 0) && (greenTGoods < greenTGcount))
+                            itemID = greenTradeGoodsBin[urand(0, greenTradeGoodsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 10:
+                    {
+                        if ((blueTradeGoodsBin.size() > 0) && (blueTGoods < blueTGcount))
+                            itemID = blueTradeGoodsBin[urand(0, blueTradeGoodsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 11:
+                    {
+                        if ((purpleTradeGoodsBin.size() > 0) && (purpleTGoods < purpleTGcount))
+                            itemID = purpleTradeGoodsBin[urand(0, purpleTradeGoodsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 12:
+                    {
+                        if ((orangeTradeGoodsBin.size() > 0) && (orangeTGoods < orangeTGcount))
+                            itemID = orangeTradeGoodsBin[urand(0, orangeTradeGoodsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                case 13:
+                    {
+                        if ((yellowTradeGoodsBin.size() > 0) && (yellowTGoods < yellowTGcount))
+                            itemID = yellowTradeGoodsBin[urand(0, yellowTradeGoodsBin.size() - 1)];
+                        else continue;
+                        break;
+                    }
+                default:
+                    {
+                        if (debug_Out) sLog->outError( "AHSeller: itemID Switch - Default Reached");
+                        break;
+                    }
                 }
-            case 1:
-                {
-                    if ((whiteItemsBin.size() > 0) && (whiteItems < whiteIcount))
-                        itemID = whiteItemsBin[urand(0, whiteItemsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 2:
-                {
-                    if ((greenItemsBin.size() > 0) && (greenItems < greenIcount))
-                        itemID = greenItemsBin[urand(0, greenItemsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 3:
-                {
-                    if ((blueItemsBin.size() > 0) && (blueItems < blueIcount))
-                        itemID = blueItemsBin[urand(0, blueItemsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 4:
-                {
-                    if ((purpleItemsBin.size() > 0) && (purpleItems < purpleIcount))
-                        itemID = purpleItemsBin[urand(0, purpleItemsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 5:
-                {
-                    if ((orangeItemsBin.size() > 0) && (orangeItems < orangeIcount))
-                        itemID = orangeItemsBin[urand(0, orangeItemsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 6:
-                {
-                    if ((yellowItemsBin.size() > 0) && (yellowItems < yellowIcount))
-                        itemID = yellowItemsBin[urand(0, yellowItemsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 7:
-                {
-                    if ((greyTradeGoodsBin.size() > 0) && (greyTGoods < greyTGcount))
-                        itemID = greyTradeGoodsBin[urand(0, greyTradeGoodsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 8:
-                {
-                    if ((whiteTradeGoodsBin.size() > 0) && (whiteTGoods < whiteTGcount))
-                        itemID = whiteTradeGoodsBin[urand(0, whiteTradeGoodsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 9:
-                {
-                    if ((greenTradeGoodsBin.size() > 0) && (greenTGoods < greenTGcount))
-                        itemID = greenTradeGoodsBin[urand(0, greenTradeGoodsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 10:
-                {
-                    if ((blueTradeGoodsBin.size() > 0) && (blueTGoods < blueTGcount))
-                        itemID = blueTradeGoodsBin[urand(0, blueTradeGoodsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 11:
-                {
-                    if ((purpleTradeGoodsBin.size() > 0) && (purpleTGoods < purpleTGcount))
-                        itemID = purpleTradeGoodsBin[urand(0, purpleTradeGoodsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 12:
-                {
-                    if ((orangeTradeGoodsBin.size() > 0) && (orangeTGoods < orangeTGcount))
-                        itemID = orangeTradeGoodsBin[urand(0, orangeTradeGoodsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            case 13:
-                {
-                    if ((yellowTradeGoodsBin.size() > 0) && (yellowTGoods < yellowTGcount))
-                        itemID = yellowTradeGoodsBin[urand(0, yellowTradeGoodsBin.size() - 1)];
-                    else continue;
-                    break;
-                }
-            default:
-                {
-                    if (debug_Out) sLog->outError( "AHSeller: itemID Switch - Default Reached");
-                    break;
-                }
-            }
             }
 
             if (itemID == 0)
@@ -437,7 +437,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
             else
             {
                 // quality is something it shouldn't be, let's get out of here
-                if (debug_Out) sLog->outError( "AHBuyer: Quality %u not Supported", prototype->Quality);
+                if (debug_Out) sLog->outError("AHSeller: Quality %u not Supported", prototype->Quality);
                 item->RemoveFromUpdateQueueOf(AHBplayer);
                 continue;
             }
@@ -483,6 +483,8 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
             auctionHouse->AddAuction(auctionEntry);
             auctionEntry->SaveToDB(trans);
             CharacterDatabase.CommitTransaction(trans);
+            if (debug_Out) sLog->outError( "AHSeller:: Inserted item. Auction ID: %u | ItemCount: %u | ItemID: %u", 
+                auctionEntry->Id, auctionEntry->itemCount, auctionEntry->item_template);
 
             switch(itemColor)
             {
@@ -534,6 +536,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
         }
     }
 }
+
 void AuctionHouseBot::addNewAuctionBuyerBotBid(Player *AHBplayer, AHBConfig *config, WorldSession *session)
 {
     if (!AHBBuyer)
@@ -888,9 +891,6 @@ void AuctionHouseBot::InitializeSellerAdvancedMode()
         ItemTemplateContainer const* its = sObjectMgr->GetItemTemplateStore();
         for (ItemTemplateContainer::const_iterator itr = its->begin(); itr != its->end(); ++itr)
         {
-
-
-
             switch (itr->second.Bonding)
             {
             case NO_BIND:
@@ -1357,7 +1357,7 @@ void AuctionHouseBot::InitializeSellerAdvancedMode()
             AHBSeller = 0;
         }
 
-        sLog->outString("AuctionHouseBot:");
+        sLog->outString("AuctionHouseBot:Seller");
         sLog->outString("%u disabled items", uint32(DisableItemStore.size()));
         sLog->outString("loaded %u grey trade goods", uint32(greyTradeGoodsBin.size()));
         sLog->outString("loaded %u white trade goods", uint32(whiteTradeGoodsBin.size()));
@@ -1490,9 +1490,9 @@ void AuctionHouseBot::IncrementItemCounts(AuctionEntry* ah)
     }
     else
     {
-    config->IncItemCounts(prototype->Class, prototype->Quality);
-}
-
+        config->IncItemCounts(prototype->Class, prototype->Quality);
+    }
+    
 }
 
 void AuctionHouseBot::DecrementItemCounts(AuctionEntry* ah, uint32 itemEntry)
@@ -1530,9 +1530,9 @@ void AuctionHouseBot::DecrementItemCounts(AuctionEntry* ah, uint32 itemEntry)
     }
     else
     {
-    config->DecItemCounts(prototype->Class, prototype->Quality);
-}
-
+        config->DecItemCounts(prototype->Class, prototype->Quality);
+    }
+    
 }
 
 void AuctionHouseBot::Commands(uint32 command, uint32 ahMapID, uint32 col, char* args)
@@ -1972,81 +1972,81 @@ void AuctionHouseBot::LoadItemCountsSimpleMode(AHBConfig *config)
 
 void AuctionHouseBot::LoadItemCountsAdvancedMode(AHBConfig *config)
 {
-        //AuctionHouseEntry const* ahEntry =  sAuctionMgr->GetAuctionHouseEntry(config->GetAHFID());
-        AuctionHouseObject* auctionHouse =  sAuctionMgr->GetAuctionsMap(config->GetAHFID());
+    //AuctionHouseEntry const* ahEntry =  sAuctionMgr->GetAuctionHouseEntry(config->GetAHFID());
+    AuctionHouseObject* auctionHouse =  sAuctionMgr->GetAuctionsMap(config->GetAHFID());
 
-        config->ResetItemCounts();
-        uint32 auctions = auctionHouse->Getcount();
+    config->ResetItemCounts();
+    uint32 auctions = auctionHouse->Getcount();
 
-        if (auctions)
+    if (auctions)
+    {
+        for (AuctionHouseObject::AuctionEntryMap::const_iterator itr = auctionHouse->GetAuctionsBegin(); itr != auctionHouse->GetAuctionsEnd(); ++itr)
         {
-            for (AuctionHouseObject::AuctionEntryMap::const_iterator itr = auctionHouse->GetAuctionsBegin(); itr != auctionHouse->GetAuctionsEnd(); ++itr)
+            AuctionEntry *Aentry = itr->second;
+            Item *item = sAuctionMgr->GetAItem(Aentry->item_guidlow);
+            if (item)
             {
-                AuctionEntry *Aentry = itr->second;
-				Item *item = sAuctionMgr->GetAItem(Aentry->item_guidlow);
-                if (item)
+                ItemTemplate const *prototype = item->GetTemplate();
+                if (prototype)
                 {
-                    ItemTemplate const *prototype = item->GetTemplate();
-                    if (prototype)
+                    switch (prototype->Quality)
                     {
-                        switch (prototype->Quality)
-                        {
-                        case 0:
-                            if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
-                                config->IncItemCounts(AHB_GREY_TG);
-                            else
-                                config->IncItemCounts(AHB_GREY_I);
-                            break;
-                        case 1:
-                            if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
-                                config->IncItemCounts(AHB_WHITE_TG);
-                            else
-                                config->IncItemCounts(AHB_WHITE_I);
-                            break;
-                        case 2:
-                            if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
-                                config->IncItemCounts(AHB_GREEN_TG);
-                            else
-                                config->IncItemCounts(AHB_GREEN_I);
-                            break;
-                        case 3:
-                            if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
-                                config->IncItemCounts(AHB_BLUE_TG);
-                            else
-                                config->IncItemCounts(AHB_BLUE_I);
-                            break;
-                        case 4:
-                            if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
-                                config->IncItemCounts(AHB_PURPLE_TG);
-                            else
-                                config->IncItemCounts(AHB_PURPLE_I);
-                            break;
-                        case 5:
-                            if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
-                                config->IncItemCounts(AHB_ORANGE_TG);
-                            else
-                                config->IncItemCounts(AHB_ORANGE_I);
-                            break;
-                        case 6:
-                            if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
-                                config->IncItemCounts(AHB_YELLOW_TG);
-                            else
-                                config->IncItemCounts(AHB_YELLOW_I);
-                            break;
-                        }
+                    case 0:
+                        if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
+                            config->IncItemCounts(AHB_GREY_TG);
+                        else
+                            config->IncItemCounts(AHB_GREY_I);
+                        break;
+                    case 1:
+                        if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
+                            config->IncItemCounts(AHB_WHITE_TG);
+                        else
+                            config->IncItemCounts(AHB_WHITE_I);
+                        break;
+                    case 2:
+                        if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
+                            config->IncItemCounts(AHB_GREEN_TG);
+                        else
+                            config->IncItemCounts(AHB_GREEN_I);
+                        break;
+                    case 3:
+                        if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
+                            config->IncItemCounts(AHB_BLUE_TG);
+                        else
+                            config->IncItemCounts(AHB_BLUE_I);
+                        break;
+                    case 4:
+                        if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
+                            config->IncItemCounts(AHB_PURPLE_TG);
+                        else
+                            config->IncItemCounts(AHB_PURPLE_I);
+                        break;
+                    case 5:
+                        if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
+                            config->IncItemCounts(AHB_ORANGE_TG);
+                        else
+                            config->IncItemCounts(AHB_ORANGE_I);
+                        break;
+                    case 6:
+                        if (prototype->Class == ITEM_CLASS_TRADE_GOODS)
+                            config->IncItemCounts(AHB_YELLOW_TG);
+                        else
+                            config->IncItemCounts(AHB_YELLOW_I);
+                        break;
                     }
                 }
             }
         }
-        if (debug_Out)
-        {
-			sLog->outError( "Current Settings for %s Auctionhouses:", WorldDatabase.PQuery("SELECT name FROM mod_auctionhousebot WHERE auctionhouse = %u", config->GetAHID())->Fetch()->GetCString());
-            sLog->outError( "Grey Trade Goods\t%u\tGrey Items\t%u", config->GetItemCounts(AHB_GREY_TG), config->GetItemCounts(AHB_GREY_I));
-            sLog->outError( "White Trade Goods\t%u\tWhite Items\t%u", config->GetItemCounts(AHB_WHITE_TG), config->GetItemCounts(AHB_WHITE_I));
-            sLog->outError( "Green Trade Goods\t%u\tGreen Items\t%u", config->GetItemCounts(AHB_GREEN_TG), config->GetItemCounts(AHB_GREEN_I));
-            sLog->outError( "Blue Trade Goods\t%u\tBlue Items\t%u", config->GetItemCounts(AHB_BLUE_TG), config->GetItemCounts(AHB_BLUE_I));
-            sLog->outError( "Purple Trade Goods\t%u\tPurple Items\t%u", config->GetItemCounts(AHB_PURPLE_TG), config->GetItemCounts(AHB_PURPLE_I));
-            sLog->outError( "Orange Trade Goods\t%u\tOrange Items\t%u", config->GetItemCounts(AHB_ORANGE_TG), config->GetItemCounts(AHB_ORANGE_I));
-            sLog->outError( "Yellow Trade Goods\t%u\tYellow Items\t%u", config->GetItemCounts(AHB_YELLOW_TG), config->GetItemCounts(AHB_YELLOW_I));
-        }
     }
+    if (debug_Out)
+    {
+        sLog->outError( "Current Settings for %s Auctionhouses:", WorldDatabase.PQuery("SELECT name FROM mod_auctionhousebot WHERE auctionhouse = %u", config->GetAHID())->Fetch()->GetCString());
+        sLog->outError( "Grey Trade Goods\t%u\tGrey Items\t%u", config->GetItemCounts(AHB_GREY_TG), config->GetItemCounts(AHB_GREY_I));
+        sLog->outError( "White Trade Goods\t%u\tWhite Items\t%u", config->GetItemCounts(AHB_WHITE_TG), config->GetItemCounts(AHB_WHITE_I));
+        sLog->outError( "Green Trade Goods\t%u\tGreen Items\t%u", config->GetItemCounts(AHB_GREEN_TG), config->GetItemCounts(AHB_GREEN_I));
+        sLog->outError( "Blue Trade Goods\t%u\tBlue Items\t%u", config->GetItemCounts(AHB_BLUE_TG), config->GetItemCounts(AHB_BLUE_I));
+        sLog->outError( "Purple Trade Goods\t%u\tPurple Items\t%u", config->GetItemCounts(AHB_PURPLE_TG), config->GetItemCounts(AHB_PURPLE_I));
+        sLog->outError( "Orange Trade Goods\t%u\tOrange Items\t%u", config->GetItemCounts(AHB_ORANGE_TG), config->GetItemCounts(AHB_ORANGE_I));
+        sLog->outError( "Yellow Trade Goods\t%u\tYellow Items\t%u", config->GetItemCounts(AHB_YELLOW_TG), config->GetItemCounts(AHB_YELLOW_I));
+    }
+}

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -252,7 +252,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
     }
 
     // only insert a few at a time, so as not to peg the processor
-    for (uint32 cnt = 1; cnt <= items || (SimpleSellerMode && (cnt - 1) < simpleMode_ItemsToInsert.size()); cnt++)
+    for (uint32 cnt = 1; cnt <= items && (SimpleSellerMode ? (cnt - 1) < simpleMode_ItemsToInsert.size() : true); cnt++)
     {
         if (debug_Out) sLog->outError( "AHSeller: %u count", cnt);
         uint32 itemID = 0;

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -442,7 +442,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
                 if (simplePrice != 0)
                 {
                     buyoutPrice = simplePrice;
-                    bidPrice = buyoutPrice/90;
+                    bidPrice = (buyoutPrice * 100) / 90;
                 }
                 else
                 {

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -170,7 +170,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
     else
         items = (maxItems - auctions);
 
-    if (debug_Out) sLog->outString("AHSeller: Adding %u Auctions", items);
+    if (debug_Out) sLog->outString("AHSeller: Can add %u Auctions this cycle", items);
 
     uint32 AuctioneerGUID = 0;
 

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -232,7 +232,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
     // If simple seller mode, decide what items to insert this cycle
     vector<uint32> simpleMode_ItemsToInsert;
     if (SimpleSellerMode) {
-        for(uint32 i = 1; simpleMode_ItemsToInsert.size() < items && i < simpleItemConfig.size(); i++) {
+        for(uint32 i = 0; simpleMode_ItemsToInsert.size() < items && i < simpleItemConfig.size(); i++) {
             SimpleItemConfigEntry simpleItemConfigEntry = simpleItemConfig[i];
             uint32 itemID = simpleItemConfigEntry.itemID;
             uint32 maxStackCount = simpleItemConfigEntry.numStacks;

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -783,6 +783,32 @@ void AuctionHouseBot::Initialize()
 
     if (AHBSeller)
     {
+        if (SimpleSellerMode) 
+        {
+            InitializeSellerSimpleMode();
+        } else {
+            InitializeSellerAdvancedMode();
+        }
+    }
+    sLog->outString("AuctionHouseBot and AuctionHouseBuyer have been loaded.");
+}
+
+void AuctionHouseBot::InitializeSellerSimpleMode()
+{
+    // TODO: QueryResult result = QueryResult result = WorldDatabase.PQuery("SELECT itemID, numStacks FROM mod_auctionhousebot_items");
+    if (simpleItemsBin.size() == 0)
+    {
+        sLog->outError( "AuctionHouseBot: No items");
+        AHBSeller = 0;
+    }
+
+    sLog->outString("AuctionHouseBot:");
+    sLog->outString("Running in simple mode");
+    sLog->outString("loaded %u items", uint32(simpleItemsBin.size()));
+}
+
+void AuctionHouseBot::InitializeSellerAdvancedMode()
+{   
         QueryResult results = QueryResult(NULL);
         char npcQuery[] = "SELECT distinct item FROM npc_vendor";
         results = WorldDatabase.Query(npcQuery);
@@ -1315,8 +1341,6 @@ void AuctionHouseBot::Initialize()
         sLog->outString("loaded %u orange items", uint32(orangeItemsBin.size()));
         sLog->outString("loaded %u yellow items", uint32(yellowItemsBin.size()));
     }
-    sLog->outString("AuctionHouseBot and AuctionHouseBuyer have been loaded.");
-}
 
 void AuctionHouseBot::InitializeConfiguration()
 {

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -402,7 +402,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
                 continue;
             }
 
-            uint32 etime = urand(1,3);
+            uint32 etime = 3;
             switch(etime)
             {
             case 1:

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -461,7 +461,7 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
                 if (simplePrice != 0)
                 {
                     buyoutPrice = simplePrice;
-                    bidPrice = (buyoutPrice * 100) / 90;
+                    bidPrice = (buyoutPrice * 90) / 100;
                 }
                 else
                 {

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -845,535 +845,535 @@ void AuctionHouseBot::InitializeSellerSimpleMode()
 
 void AuctionHouseBot::InitializeSellerAdvancedMode()
 {   
-        QueryResult results = QueryResult(NULL);
-        char npcQuery[] = "SELECT distinct item FROM npc_vendor";
-        results = WorldDatabase.Query(npcQuery);
-        if (results)
+    QueryResult results = QueryResult(NULL);
+    char npcQuery[] = "SELECT distinct item FROM npc_vendor";
+    results = WorldDatabase.Query(npcQuery);
+    if (results)
+    {
+        do
         {
-            do
-            {
-                Field* fields = results->Fetch();
-                npcItems.push_back(fields[0].GetUInt32());
+            Field* fields = results->Fetch();
+            npcItems.push_back(fields[0].GetUInt32());
 
-            } while (results->NextRow());
-        }
-        else
-        {
-            if (debug_Out) sLog->outError( "AuctionHouseBot: \"%s\" failed", npcQuery);
-        }
-
-        char lootQuery[] = "SELECT item FROM creature_loot_template UNION "
-            "SELECT item FROM reference_loot_template UNION "
-            "SELECT item FROM disenchant_loot_template UNION "
-            "SELECT item FROM fishing_loot_template UNION "
-            "SELECT item FROM gameobject_loot_template UNION "
-            "SELECT item FROM item_loot_template UNION "
-            "SELECT item FROM milling_loot_template UNION "
-            "SELECT item FROM pickpocketing_loot_template UNION "
-            "SELECT item FROM prospecting_loot_template UNION "
-            "SELECT item FROM skinning_loot_template";
-
-        results = WorldDatabase.Query(lootQuery);
-        if (results)
-        {
-            do
-            {
-                Field* fields = results->Fetch();
-                lootItems.push_back(fields[0].GetUInt32());
-
-            } while (results->NextRow());
-        }
-        else
-        {
-            if (debug_Out) sLog->outError( "AuctionHouseBot: \"%s\" failed", lootQuery);
-        }
-
-        ItemTemplateContainer const* its = sObjectMgr->GetItemTemplateStore();
-        for (ItemTemplateContainer::const_iterator itr = its->begin(); itr != its->end(); ++itr)
-        {
-            switch (itr->second.Bonding)
-            {
-            case NO_BIND:
-                if (!No_Bind)
-                    continue;
-                break;
-            case BIND_WHEN_PICKED_UP:
-                if (!Bind_When_Picked_Up)
-                    continue;
-                break;
-            case BIND_WHEN_EQUIPED:
-                if (!Bind_When_Equipped)
-                    continue;
-                break;
-            case BIND_WHEN_USE:
-                if (!Bind_When_Use)
-                    continue;
-                break;
-            case BIND_QUEST_ITEM:
-                if (!Bind_Quest_Item)
-                    continue;
-                break;
-            default:
-                continue;
-                break;
-            }
-
-            if (SellMethod)
-            {
-                if (itr->second.BuyPrice == 0)
-                    continue;
-            }
-            else
-            {
-                if (itr->second.SellPrice == 0)
-                    continue;
-            }
-
-            if (itr->second.Quality > 6)
-                continue;
-
-            if ((Vendor_Items == 0) && !(itr->second.Class == ITEM_CLASS_TRADE_GOODS))
-            {
-                bool isVendorItem = false;
-
-                for (unsigned int i = 0; (i < npcItems.size()) && (!isVendorItem); i++)
-                {
-                    if (itr->second.ItemId == npcItems[i])
-                        isVendorItem = true;
-                }
-
-                if (isVendorItem)
-                    continue;
-            }
-
-            if ((Vendor_TGs == 0) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS))
-            {
-                bool isVendorTG = false;
-
-                for (unsigned int i = 0; (i < npcItems.size()) && (!isVendorTG); i++)
-                {
-                    if (itr->second.ItemId == npcItems[i])
-                        isVendorTG = true;
-                }
-
-                if (isVendorTG)
-                    continue;
-            }
-
-            if ((Loot_Items == 0) && !(itr->second.Class == ITEM_CLASS_TRADE_GOODS))
-            {
-                bool isLootItem = false;
-
-                for (unsigned int i = 0; (i < lootItems.size()) && (!isLootItem); i++)
-                {
-                    if (itr->second.ItemId == lootItems[i])
-                        isLootItem = true;
-                }
-
-                if (isLootItem)
-                    continue;
-            }
-
-            if ((Loot_TGs == 0) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS))
-            {
-                bool isLootTG = false;
-
-                for (unsigned int i = 0; (i < lootItems.size()) && (!isLootTG); i++)
-                {
-                    if (itr->second.ItemId == lootItems[i])
-                        isLootTG = true;
-                }
-
-                if (isLootTG)
-                    continue;
-            }
-
-            if ((Other_Items == 0) && !(itr->second.Class == ITEM_CLASS_TRADE_GOODS))
-            {
-                bool isVendorItem = false;
-                bool isLootItem = false;
-
-                for (unsigned int i = 0; (i < npcItems.size()) && (!isVendorItem); i++)
-                {
-                    if (itr->second.ItemId == npcItems[i])
-                        isVendorItem = true;
-                }
-                for (unsigned int i = 0; (i < lootItems.size()) && (!isLootItem); i++)
-                {
-                    if (itr->second.ItemId == lootItems[i])
-                        isLootItem = true;
-                }
-                if ((!isLootItem) && (!isVendorItem))
-                    continue;
-            }
-
-            if ((Other_TGs == 0) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS))
-            {
-                bool isVendorTG = false;
-                bool isLootTG = false;
-
-                for (unsigned int i = 0; (i < npcItems.size()) && (!isVendorTG); i++)
-                {
-                    if (itr->second.ItemId == npcItems[i])
-                        isVendorTG = true;
-                }
-                for (unsigned int i = 0; (i < lootItems.size()) && (!isLootTG); i++)
-                {
-                    if (itr->second.ItemId == lootItems[i])
-                        isLootTG = true;
-                }
-                if ((!isLootTG) && (!isVendorTG))
-                    continue;
-            }
-
-            // Disable items by Id
-            if (DisableItemStore.find(itr->second.ItemId) != DisableItemStore.end())
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (PTR/Beta/Unused Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable permanent enchants items
-            if ((DisablePermEnchant) && (itr->second.Class == ITEM_CLASS_PERMANENT))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Permanent Enchant Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable conjured items
-            if ((DisableConjured) && (itr->second.IsConjuredConsumable()))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Conjured Consumable)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable gems
-            if ((DisableGems) && (itr->second.Class == ITEM_CLASS_GEM))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Gem)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable money
-            if ((DisableMoney) && (itr->second.Class == ITEM_CLASS_MONEY))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Money)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable moneyloot
-            if ((DisableMoneyLoot) && (itr->second.MinMoneyLoot > 0))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (MoneyLoot)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable lootable items
-            if ((DisableLootable) && (itr->second.Flags & 4))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Lootable Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable Keys
-            if ((DisableKeys) && (itr->second.Class == ITEM_CLASS_KEY))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Quest Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items with duration
-            if ((DisableDuration) && (itr->second.Duration > 0))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Has a Duration)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items which are BOP or Quest Items and have a required level lower than the item level
-            if ((DisableBOP_Or_Quest_NoReqLevel) && ((itr->second.Bonding == BIND_WHEN_PICKED_UP || itr->second.Bonding == BIND_QUEST_ITEM) && (itr->second.RequiredLevel < itr->second.ItemLevel)))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (BOP or BQI and Required Level is less than Item Level)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Warrior
-            if ((DisableWarriorItems) && (itr->second.AllowableClass == 1))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Warrior Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Paladin
-            if ((DisablePaladinItems) && (itr->second.AllowableClass == 2))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Paladin Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Hunter
-            if ((DisableHunterItems) && (itr->second.AllowableClass == 4))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Hunter Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Rogue
-            if ((DisableRogueItems) && (itr->second.AllowableClass == 8))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Rogue Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Priest
-            if ((DisablePriestItems) && (itr->second.AllowableClass == 16))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Priest Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for DK
-            if ((DisableDKItems) && (itr->second.AllowableClass == 32))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (DK Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Shaman
-            if ((DisableShamanItems) && (itr->second.AllowableClass == 64))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Shaman Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Mage
-            if ((DisableMageItems) && (itr->second.AllowableClass == 128))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Mage Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Warlock
-            if ((DisableWarlockItems) && (itr->second.AllowableClass == 256))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Warlock Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Unused Class
-            if ((DisableUnusedClassItems) && (itr->second.AllowableClass == 512))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Unused Item)", itr->second.ItemId);
-                continue;
-            }
-
-            // Disable items specifically for Druid
-            if ((DisableDruidItems) && (itr->second.AllowableClass == 1024))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Druid Item)", itr->second.ItemId);
-                continue;
-            }
-
-             // Disable Items below level X
-            if ((DisableItemsBelowLevel) && (itr->second.Class != ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemLevel < DisableItemsBelowLevel))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Item Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
-                continue;
-            }
-
-            // Disable Items above level X
-            if ((DisableItemsAboveLevel) && (itr->second.Class != ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemLevel > DisableItemsAboveLevel))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Item Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
-                continue;
-            }
-
-           // Disable Trade Goods below level X
-            if ((DisableTGsBelowLevel) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemLevel < DisableTGsBelowLevel))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Trade Good %u disabled (Trade Good Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
-                continue;
-            }
-
-           // Disable Trade Goods above level X
-            if ((DisableTGsAboveLevel) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemLevel > DisableTGsAboveLevel))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Trade Good %u disabled (Trade Good Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
-                continue;
-            }
-
-            // Disable Items below GUID X
-            if ((DisableItemsBelowGUID) && (itr->second.Class != ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemId < DisableItemsBelowGUID))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Item Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
-                continue;
-            }
-
-            // Disable Items above GUID X
-            if ((DisableItemsAboveGUID) && (itr->second.Class != ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemId > DisableItemsAboveGUID))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Item Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
-                continue;
-            }
-
-            // Disable Trade Goods below GUID X
-            if ((DisableTGsBelowGUID) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemId < DisableTGsBelowGUID))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Trade Good Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
-                continue;
-            }
-
-            // Disable Trade Goods above GUID X
-            if ((DisableTGsAboveGUID) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemId > DisableTGsAboveGUID))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Trade Good Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
-                continue;
-            }
-
-            // Disable Items for level lower than X
-            if ((DisableItemsBelowReqLevel) && (itr->second.RequiredLevel < DisableItemsBelowReqLevel))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredLevel = %u)", itr->second.ItemId, itr->second.RequiredLevel);
-                continue;
-            }
-
-            // Disable Items for level higher than X
-            if ((DisableItemsAboveReqLevel) && (itr->second.RequiredLevel > DisableItemsAboveReqLevel))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredLevel = %u)", itr->second.ItemId, itr->second.RequiredLevel);
-                continue;
-            }
-
-            // Disable Trade Goods for level lower than X
-            if ((DisableTGsBelowReqLevel) && (itr->second.RequiredLevel < DisableTGsBelowReqLevel))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Trade Good %u disabled (RequiredLevel = %u)", itr->second.ItemId, itr->second.RequiredLevel);
-                continue;
-            }
-
-            // Disable Trade Goods for level higher than X
-            if ((DisableTGsAboveReqLevel) && (itr->second.RequiredLevel > DisableTGsAboveReqLevel))
-            {
-                if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Trade Good %u disabled (RequiredLevel = %u)", itr->second.ItemId, itr->second.RequiredLevel);
-                continue;
-            }
-
-            // Disable Items that require skill lower than X
-            // if ((DisableItemsBelowReqSkillRank) && (itr->second.RequiredSkillRank < DisableItemsBelowReqSkillRank))
-            // {
-            //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
-            //    continue;
-            // }
-
-            // Disable Items that require skill higher than X
-            // if ((DisableItemsAboveReqSkillRank) && (itr->second.RequiredSkillRank > DisableItemsAboveReqSkillRank))
-            // {
-            //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
-            //    continue;
-            // }
-
-            // Disable Trade Goods that require skill lower than X
-            // if ((DisableTGsBelowReqSkillRank) && (itr->second.RequiredSkillRank < DisableTGsBelowReqSkillRank))
-            // {
-            //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
-            //    continue;
-            // }
-
-            // Disable Trade Goods that require skill higher than X
-            // if ((DisableTGsAboveReqSkillRank) && (itr->second.?RequiredSkillRank > DisableTGsAboveReqSkillRank))
-            // {
-            //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
-            //    continue;
-            // }
-
-            switch (itr->second.Quality)
-            {
-            case AHB_GREY:
-                if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
-                    greyTradeGoodsBin.push_back(itr->second.ItemId);
-                else
-                    greyItemsBin.push_back(itr->second.ItemId);
-                break;
-
-            case AHB_WHITE:
-                if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
-                    whiteTradeGoodsBin.push_back(itr->second.ItemId);
-                else
-                    whiteItemsBin.push_back(itr->second.ItemId);
-                break;
-
-            case AHB_GREEN:
-                if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
-                    greenTradeGoodsBin.push_back(itr->second.ItemId);
-                else
-                    greenItemsBin.push_back(itr->second.ItemId);
-                break;
-
-            case AHB_BLUE:
-                if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
-                    blueTradeGoodsBin.push_back(itr->second.ItemId);
-                else
-                    blueItemsBin.push_back(itr->second.ItemId);
-                break;
-
-            case AHB_PURPLE:
-                if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
-                    purpleTradeGoodsBin.push_back(itr->second.ItemId);
-                else
-                    purpleItemsBin.push_back(itr->second.ItemId);
-                break;
-
-            case AHB_ORANGE:
-                if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
-                    orangeTradeGoodsBin.push_back(itr->second.ItemId);
-                else
-                    orangeItemsBin.push_back(itr->second.ItemId);
-                break;
-
-            case AHB_YELLOW:
-                if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
-                    yellowTradeGoodsBin.push_back(itr->second.ItemId);
-                else
-                    yellowItemsBin.push_back(itr->second.ItemId);
-                break;
-            }
-        }
-
-        if ((greyTradeGoodsBin.size() == 0) &&
-            (whiteTradeGoodsBin.size() == 0) &&
-            (greenTradeGoodsBin.size() == 0) &&
-            (blueTradeGoodsBin.size() == 0) &&
-            (purpleTradeGoodsBin.size() == 0) &&
-            (orangeTradeGoodsBin.size() == 0) &&
-            (yellowTradeGoodsBin.size() == 0) &&
-            (greyItemsBin.size() == 0) &&
-            (whiteItemsBin.size() == 0) &&
-            (greenItemsBin.size() == 0) &&
-            (blueItemsBin.size() == 0) &&
-            (purpleItemsBin.size() == 0) &&
-            (orangeItemsBin.size() == 0) &&
-            (yellowItemsBin.size() == 0))
-        {
-            sLog->outError( "AuctionHouseBot: No items");
-            AHBSeller = 0;
-        }
-
-        sLog->outString("AuctionHouseBot:Seller");
-        sLog->outString("%u disabled items", uint32(DisableItemStore.size()));
-        sLog->outString("loaded %u grey trade goods", uint32(greyTradeGoodsBin.size()));
-        sLog->outString("loaded %u white trade goods", uint32(whiteTradeGoodsBin.size()));
-        sLog->outString("loaded %u green trade goods", uint32(greenTradeGoodsBin.size()));
-        sLog->outString("loaded %u blue trade goods", uint32(blueTradeGoodsBin.size()));
-        sLog->outString("loaded %u purple trade goods", uint32(purpleTradeGoodsBin.size()));
-        sLog->outString("loaded %u orange trade goods", uint32(orangeTradeGoodsBin.size()));
-        sLog->outString("loaded %u yellow trade goods", uint32(yellowTradeGoodsBin.size()));
-        sLog->outString("loaded %u grey items", uint32(greyItemsBin.size()));
-        sLog->outString("loaded %u white items", uint32(whiteItemsBin.size()));
-        sLog->outString("loaded %u green items", uint32(greenItemsBin.size()));
-        sLog->outString("loaded %u blue items", uint32(blueItemsBin.size()));
-        sLog->outString("loaded %u purple items", uint32(purpleItemsBin.size()));
-        sLog->outString("loaded %u orange items", uint32(orangeItemsBin.size()));
-        sLog->outString("loaded %u yellow items", uint32(yellowItemsBin.size()));
+        } while (results->NextRow());
     }
+    else
+    {
+        if (debug_Out) sLog->outError( "AuctionHouseBot: \"%s\" failed", npcQuery);
+    }
+
+    char lootQuery[] = "SELECT item FROM creature_loot_template UNION "
+        "SELECT item FROM reference_loot_template UNION "
+        "SELECT item FROM disenchant_loot_template UNION "
+        "SELECT item FROM fishing_loot_template UNION "
+        "SELECT item FROM gameobject_loot_template UNION "
+        "SELECT item FROM item_loot_template UNION "
+        "SELECT item FROM milling_loot_template UNION "
+        "SELECT item FROM pickpocketing_loot_template UNION "
+        "SELECT item FROM prospecting_loot_template UNION "
+        "SELECT item FROM skinning_loot_template";
+
+    results = WorldDatabase.Query(lootQuery);
+    if (results)
+    {
+        do
+        {
+            Field* fields = results->Fetch();
+            lootItems.push_back(fields[0].GetUInt32());
+
+        } while (results->NextRow());
+    }
+    else
+    {
+        if (debug_Out) sLog->outError( "AuctionHouseBot: \"%s\" failed", lootQuery);
+    }
+
+    ItemTemplateContainer const* its = sObjectMgr->GetItemTemplateStore();
+    for (ItemTemplateContainer::const_iterator itr = its->begin(); itr != its->end(); ++itr)
+    {
+        switch (itr->second.Bonding)
+        {
+        case NO_BIND:
+            if (!No_Bind)
+                continue;
+            break;
+        case BIND_WHEN_PICKED_UP:
+            if (!Bind_When_Picked_Up)
+                continue;
+            break;
+        case BIND_WHEN_EQUIPED:
+            if (!Bind_When_Equipped)
+                continue;
+            break;
+        case BIND_WHEN_USE:
+            if (!Bind_When_Use)
+                continue;
+            break;
+        case BIND_QUEST_ITEM:
+            if (!Bind_Quest_Item)
+                continue;
+            break;
+        default:
+            continue;
+            break;
+        }
+
+        if (SellMethod)
+        {
+            if (itr->second.BuyPrice == 0)
+                continue;
+        }
+        else
+        {
+            if (itr->second.SellPrice == 0)
+                continue;
+        }
+
+        if (itr->second.Quality > 6)
+            continue;
+
+        if ((Vendor_Items == 0) && !(itr->second.Class == ITEM_CLASS_TRADE_GOODS))
+        {
+            bool isVendorItem = false;
+
+            for (unsigned int i = 0; (i < npcItems.size()) && (!isVendorItem); i++)
+            {
+                if (itr->second.ItemId == npcItems[i])
+                    isVendorItem = true;
+            }
+
+            if (isVendorItem)
+                continue;
+        }
+
+        if ((Vendor_TGs == 0) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS))
+        {
+            bool isVendorTG = false;
+
+            for (unsigned int i = 0; (i < npcItems.size()) && (!isVendorTG); i++)
+            {
+                if (itr->second.ItemId == npcItems[i])
+                    isVendorTG = true;
+            }
+
+            if (isVendorTG)
+                continue;
+        }
+
+        if ((Loot_Items == 0) && !(itr->second.Class == ITEM_CLASS_TRADE_GOODS))
+        {
+            bool isLootItem = false;
+
+            for (unsigned int i = 0; (i < lootItems.size()) && (!isLootItem); i++)
+            {
+                if (itr->second.ItemId == lootItems[i])
+                    isLootItem = true;
+            }
+
+            if (isLootItem)
+                continue;
+        }
+
+        if ((Loot_TGs == 0) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS))
+        {
+            bool isLootTG = false;
+
+            for (unsigned int i = 0; (i < lootItems.size()) && (!isLootTG); i++)
+            {
+                if (itr->second.ItemId == lootItems[i])
+                    isLootTG = true;
+            }
+
+            if (isLootTG)
+                continue;
+        }
+
+        if ((Other_Items == 0) && !(itr->second.Class == ITEM_CLASS_TRADE_GOODS))
+        {
+            bool isVendorItem = false;
+            bool isLootItem = false;
+
+            for (unsigned int i = 0; (i < npcItems.size()) && (!isVendorItem); i++)
+            {
+                if (itr->second.ItemId == npcItems[i])
+                    isVendorItem = true;
+            }
+            for (unsigned int i = 0; (i < lootItems.size()) && (!isLootItem); i++)
+            {
+                if (itr->second.ItemId == lootItems[i])
+                    isLootItem = true;
+            }
+            if ((!isLootItem) && (!isVendorItem))
+                continue;
+        }
+
+        if ((Other_TGs == 0) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS))
+        {
+            bool isVendorTG = false;
+            bool isLootTG = false;
+
+            for (unsigned int i = 0; (i < npcItems.size()) && (!isVendorTG); i++)
+            {
+                if (itr->second.ItemId == npcItems[i])
+                    isVendorTG = true;
+            }
+            for (unsigned int i = 0; (i < lootItems.size()) && (!isLootTG); i++)
+            {
+                if (itr->second.ItemId == lootItems[i])
+                    isLootTG = true;
+            }
+            if ((!isLootTG) && (!isVendorTG))
+                continue;
+        }
+
+        // Disable items by Id
+        if (DisableItemStore.find(itr->second.ItemId) != DisableItemStore.end())
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (PTR/Beta/Unused Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable permanent enchants items
+        if ((DisablePermEnchant) && (itr->second.Class == ITEM_CLASS_PERMANENT))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Permanent Enchant Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable conjured items
+        if ((DisableConjured) && (itr->second.IsConjuredConsumable()))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Conjured Consumable)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable gems
+        if ((DisableGems) && (itr->second.Class == ITEM_CLASS_GEM))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Gem)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable money
+        if ((DisableMoney) && (itr->second.Class == ITEM_CLASS_MONEY))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Money)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable moneyloot
+        if ((DisableMoneyLoot) && (itr->second.MinMoneyLoot > 0))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (MoneyLoot)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable lootable items
+        if ((DisableLootable) && (itr->second.Flags & 4))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Lootable Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable Keys
+        if ((DisableKeys) && (itr->second.Class == ITEM_CLASS_KEY))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Quest Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items with duration
+        if ((DisableDuration) && (itr->second.Duration > 0))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Has a Duration)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items which are BOP or Quest Items and have a required level lower than the item level
+        if ((DisableBOP_Or_Quest_NoReqLevel) && ((itr->second.Bonding == BIND_WHEN_PICKED_UP || itr->second.Bonding == BIND_QUEST_ITEM) && (itr->second.RequiredLevel < itr->second.ItemLevel)))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (BOP or BQI and Required Level is less than Item Level)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Warrior
+        if ((DisableWarriorItems) && (itr->second.AllowableClass == 1))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Warrior Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Paladin
+        if ((DisablePaladinItems) && (itr->second.AllowableClass == 2))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Paladin Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Hunter
+        if ((DisableHunterItems) && (itr->second.AllowableClass == 4))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Hunter Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Rogue
+        if ((DisableRogueItems) && (itr->second.AllowableClass == 8))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Rogue Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Priest
+        if ((DisablePriestItems) && (itr->second.AllowableClass == 16))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Priest Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for DK
+        if ((DisableDKItems) && (itr->second.AllowableClass == 32))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (DK Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Shaman
+        if ((DisableShamanItems) && (itr->second.AllowableClass == 64))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Shaman Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Mage
+        if ((DisableMageItems) && (itr->second.AllowableClass == 128))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Mage Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Warlock
+        if ((DisableWarlockItems) && (itr->second.AllowableClass == 256))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Warlock Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Unused Class
+        if ((DisableUnusedClassItems) && (itr->second.AllowableClass == 512))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Unused Item)", itr->second.ItemId);
+            continue;
+        }
+
+        // Disable items specifically for Druid
+        if ((DisableDruidItems) && (itr->second.AllowableClass == 1024))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Druid Item)", itr->second.ItemId);
+            continue;
+        }
+
+            // Disable Items below level X
+        if ((DisableItemsBelowLevel) && (itr->second.Class != ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemLevel < DisableItemsBelowLevel))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Item Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
+            continue;
+        }
+
+        // Disable Items above level X
+        if ((DisableItemsAboveLevel) && (itr->second.Class != ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemLevel > DisableItemsAboveLevel))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Item Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
+            continue;
+        }
+
+        // Disable Trade Goods below level X
+        if ((DisableTGsBelowLevel) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemLevel < DisableTGsBelowLevel))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Trade Good %u disabled (Trade Good Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
+            continue;
+        }
+
+        // Disable Trade Goods above level X
+        if ((DisableTGsAboveLevel) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemLevel > DisableTGsAboveLevel))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Trade Good %u disabled (Trade Good Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
+            continue;
+        }
+
+        // Disable Items below GUID X
+        if ((DisableItemsBelowGUID) && (itr->second.Class != ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemId < DisableItemsBelowGUID))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Item Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
+            continue;
+        }
+
+        // Disable Items above GUID X
+        if ((DisableItemsAboveGUID) && (itr->second.Class != ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemId > DisableItemsAboveGUID))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Item Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
+            continue;
+        }
+
+        // Disable Trade Goods below GUID X
+        if ((DisableTGsBelowGUID) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemId < DisableTGsBelowGUID))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Trade Good Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
+            continue;
+        }
+
+        // Disable Trade Goods above GUID X
+        if ((DisableTGsAboveGUID) && (itr->second.Class == ITEM_CLASS_TRADE_GOODS) && (itr->second.ItemId > DisableTGsAboveGUID))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (Trade Good Level = %u)", itr->second.ItemId, itr->second.ItemLevel);
+            continue;
+        }
+
+        // Disable Items for level lower than X
+        if ((DisableItemsBelowReqLevel) && (itr->second.RequiredLevel < DisableItemsBelowReqLevel))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredLevel = %u)", itr->second.ItemId, itr->second.RequiredLevel);
+            continue;
+        }
+
+        // Disable Items for level higher than X
+        if ((DisableItemsAboveReqLevel) && (itr->second.RequiredLevel > DisableItemsAboveReqLevel))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredLevel = %u)", itr->second.ItemId, itr->second.RequiredLevel);
+            continue;
+        }
+
+        // Disable Trade Goods for level lower than X
+        if ((DisableTGsBelowReqLevel) && (itr->second.RequiredLevel < DisableTGsBelowReqLevel))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Trade Good %u disabled (RequiredLevel = %u)", itr->second.ItemId, itr->second.RequiredLevel);
+            continue;
+        }
+
+        // Disable Trade Goods for level higher than X
+        if ((DisableTGsAboveReqLevel) && (itr->second.RequiredLevel > DisableTGsAboveReqLevel))
+        {
+            if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Trade Good %u disabled (RequiredLevel = %u)", itr->second.ItemId, itr->second.RequiredLevel);
+            continue;
+        }
+
+        // Disable Items that require skill lower than X
+        // if ((DisableItemsBelowReqSkillRank) && (itr->second.RequiredSkillRank < DisableItemsBelowReqSkillRank))
+        // {
+        //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
+        //    continue;
+        // }
+
+        // Disable Items that require skill higher than X
+        // if ((DisableItemsAboveReqSkillRank) && (itr->second.RequiredSkillRank > DisableItemsAboveReqSkillRank))
+        // {
+        //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
+        //    continue;
+        // }
+
+        // Disable Trade Goods that require skill lower than X
+        // if ((DisableTGsBelowReqSkillRank) && (itr->second.RequiredSkillRank < DisableTGsBelowReqSkillRank))
+        // {
+        //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
+        //    continue;
+        // }
+
+        // Disable Trade Goods that require skill higher than X
+        // if ((DisableTGsAboveReqSkillRank) && (itr->second.?RequiredSkillRank > DisableTGsAboveReqSkillRank))
+        // {
+        //    if (debug_Out_Filters) sLog->outError( "AuctionHouseBot: Item %u disabled (RequiredSkillRank = %u)", itr->second.ItemId, itr->second.RequiredSkillRank);
+        //    continue;
+        // }
+
+        switch (itr->second.Quality)
+        {
+        case AHB_GREY:
+            if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
+                greyTradeGoodsBin.push_back(itr->second.ItemId);
+            else
+                greyItemsBin.push_back(itr->second.ItemId);
+            break;
+
+        case AHB_WHITE:
+            if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
+                whiteTradeGoodsBin.push_back(itr->second.ItemId);
+            else
+                whiteItemsBin.push_back(itr->second.ItemId);
+            break;
+
+        case AHB_GREEN:
+            if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
+                greenTradeGoodsBin.push_back(itr->second.ItemId);
+            else
+                greenItemsBin.push_back(itr->second.ItemId);
+            break;
+
+        case AHB_BLUE:
+            if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
+                blueTradeGoodsBin.push_back(itr->second.ItemId);
+            else
+                blueItemsBin.push_back(itr->second.ItemId);
+            break;
+
+        case AHB_PURPLE:
+            if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
+                purpleTradeGoodsBin.push_back(itr->second.ItemId);
+            else
+                purpleItemsBin.push_back(itr->second.ItemId);
+            break;
+
+        case AHB_ORANGE:
+            if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
+                orangeTradeGoodsBin.push_back(itr->second.ItemId);
+            else
+                orangeItemsBin.push_back(itr->second.ItemId);
+            break;
+
+        case AHB_YELLOW:
+            if (itr->second.Class == ITEM_CLASS_TRADE_GOODS)
+                yellowTradeGoodsBin.push_back(itr->second.ItemId);
+            else
+                yellowItemsBin.push_back(itr->second.ItemId);
+            break;
+        }
+    }
+
+    if ((greyTradeGoodsBin.size() == 0) &&
+        (whiteTradeGoodsBin.size() == 0) &&
+        (greenTradeGoodsBin.size() == 0) &&
+        (blueTradeGoodsBin.size() == 0) &&
+        (purpleTradeGoodsBin.size() == 0) &&
+        (orangeTradeGoodsBin.size() == 0) &&
+        (yellowTradeGoodsBin.size() == 0) &&
+        (greyItemsBin.size() == 0) &&
+        (whiteItemsBin.size() == 0) &&
+        (greenItemsBin.size() == 0) &&
+        (blueItemsBin.size() == 0) &&
+        (purpleItemsBin.size() == 0) &&
+        (orangeItemsBin.size() == 0) &&
+        (yellowItemsBin.size() == 0))
+    {
+        sLog->outError( "AuctionHouseBot: No items");
+        AHBSeller = 0;
+    }
+
+    sLog->outString("AuctionHouseBot:Seller");
+    sLog->outString("%u disabled items", uint32(DisableItemStore.size()));
+    sLog->outString("loaded %u grey trade goods", uint32(greyTradeGoodsBin.size()));
+    sLog->outString("loaded %u white trade goods", uint32(whiteTradeGoodsBin.size()));
+    sLog->outString("loaded %u green trade goods", uint32(greenTradeGoodsBin.size()));
+    sLog->outString("loaded %u blue trade goods", uint32(blueTradeGoodsBin.size()));
+    sLog->outString("loaded %u purple trade goods", uint32(purpleTradeGoodsBin.size()));
+    sLog->outString("loaded %u orange trade goods", uint32(orangeTradeGoodsBin.size()));
+    sLog->outString("loaded %u yellow trade goods", uint32(yellowTradeGoodsBin.size()));
+    sLog->outString("loaded %u grey items", uint32(greyItemsBin.size()));
+    sLog->outString("loaded %u white items", uint32(whiteItemsBin.size()));
+    sLog->outString("loaded %u green items", uint32(greenItemsBin.size()));
+    sLog->outString("loaded %u blue items", uint32(blueItemsBin.size()));
+    sLog->outString("loaded %u purple items", uint32(purpleItemsBin.size()));
+    sLog->outString("loaded %u orange items", uint32(orangeItemsBin.size()));
+    sLog->outString("loaded %u yellow items", uint32(yellowItemsBin.size()));
+}
 
 void AuctionHouseBot::InitializeConfiguration()
 {

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -238,8 +238,8 @@ void AuctionHouseBot::addNewAuctions(Player *AHBplayer, AHBConfig *config)
             uint32 sellPricePerItem = simpleItemConfigEntry.sellPrice;
             uint32 maxStackCount = simpleItemConfigEntry.numStacks;
             uint32 currentStackCount = config->GetSimpleItemCount(itemID);
-            if (debug_Out) sLog->outError( "AHSeller::SimpleMode: Item ID: %u | Current Count: %u | MaxStacks: %u",
-                itemID, currentStackCount, maxStackCount);
+            if (debug_Out) sLog->outError( "AHSeller::SimpleMode: Item ID: %u | CurrentCount: %u | SellPricePerItem: %u | MaxStacks: %u",
+                itemID, currentStackCount, sellPricePerItem, maxStackCount);
 
             for (uint32 j = currentStackCount;
                 j < maxStackCount && simpleMode_ItemsToInsert.size() < items;
@@ -1781,9 +1781,10 @@ void AuctionHouseBot::LoadSimpleItemConfig()
             simpleItemConfigEntry.numStacks = fields[1].GetUInt32();
             simpleItemConfigEntry.sellPrice = fields[2].GetUInt32();
             simpleItemConfig.push_back(simpleItemConfigEntry);
-            if (debug_Out) sLog->outError( "AuctionHouseBot:LoadSimpleItemConfig loaded entry. itemID: %u, numStacks: %u", 
+            if (debug_Out) sLog->outError( "AuctionHouseBot:LoadSimpleItemConfig loaded entry. itemID: %u, numStacks: %u, sellPrice: %u", 
                 simpleItemConfigEntry.itemID,
-                simpleItemConfigEntry.numStacks);
+                simpleItemConfigEntry.numStacks,
+                simpleItemConfigEntry.sellPrice);
         } while (results->NextRow());
     }
     else

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -21,6 +21,7 @@
 #define AUCTION_HOUSE_BOT_H
 
 #include "Common.h"
+#include "ObjectGuid.h"
 
 struct AuctionEntry;
 class Player;
@@ -1160,7 +1161,7 @@ private:
     bool SellMethod;
 
     uint32 AHBplayerAccount;
-    uint32 AHBplayerGUID;
+    ObjectGuid::LowType AHBplayerGUID;
     uint32 ItemsPerCycle;
 
     //Begin Filters
@@ -1251,7 +1252,7 @@ public:
     void DecrementItemCounts(AuctionEntry* ah, uint32 itemEntry);
     void IncrementItemCounts(AuctionEntry* ah);
     void Commands(uint32, uint32, uint32, char*);
-    uint32 GetAHBplayerGUID() { return AHBplayerGUID; };
+    ObjectGuid::LowType GetAHBplayerGUID() { return AHBplayerGUID; };
 };
 
 #define auctionbot AuctionHouseBot::instance()

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -51,6 +51,12 @@ class WorldSession;
 #define AHB_ORANGE_I    12
 #define AHB_YELLOW_I    13
 
+struct SimpleItemConfigEntry
+{
+    uint32 itemID;
+    uint32 numStacks;
+};
+
 class AHBConfig
 {
 private:
@@ -1247,8 +1253,13 @@ public:
     ~AuctionHouseBot();
     void Update();
     void Initialize();
+    void InitializeSellerSimpleMode();
+    void InitializeSellerAdvancedMode();
     void InitializeConfiguration();
     void LoadValues(AHBConfig*);
+    void LoadSimpleItemConfig();
+    void LoadItemCountsSimpleMode(AHBConfig *config);
+    void LoadItemCountsAdvancedMode(AHBConfig *config);
     void DecrementItemCounts(AuctionEntry* ah, uint32 itemEntry);
     void IncrementItemCounts(AuctionEntry* ah);
     void Commands(uint32, uint32, uint32, char*);

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -139,6 +139,8 @@ private:
     uint32 orangeip;
     uint32 yellowip;
 
+    std::unordered_map<uint32, uint32> simpleItemID_stackCount;
+
     uint32 greyTGoods;
     uint32 whiteTGoods;
     uint32 greenTGoods;
@@ -1088,6 +1090,42 @@ public:
         purpleItems +
         orangeItems +
         yellowItems);
+    }
+
+    void DecSimpleItemCount(uint32 itemID)
+    {
+        uint32 count = GetSimpleItemCount(itemID);
+        count -= 1;
+        simpleItemID_stackCount[itemID] = count;
+    }
+
+    void IncSimpleItemCount(uint32 itemID)
+    {
+        uint32 count = GetSimpleItemCount(itemID);
+        count += 1;
+        simpleItemID_stackCount[itemID] = count;
+    }
+
+    void ResetSimpleItemCounts() 
+    {
+        simpleItemID_stackCount.clear();
+    }
+
+    uint32 GetSimpleItemCount(uint32 itemID)
+    {
+        std::unordered_map<uint32, uint32>::const_iterator itemCountIterator = simpleItemID_stackCount.find(itemID);
+        uint32 itemCount = 0;
+        if(itemCountIterator == simpleItemID_stackCount.end()) {
+            itemCount = 0;
+        } else {
+            itemCount = itemCountIterator->second;
+        }
+        return itemCount;
+    }
+
+    uint32 DebugGetSimpleItemNumEntries()
+    {
+        return simpleItemID_stackCount.size();
     }
 
     uint32 GetItemCounts(uint32 color)

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -1155,6 +1155,7 @@ private:
     bool debug_Out_Filters;
 
     bool AHBSeller;
+    bool SimpleSellerMode;
     bool AHBBuyer;
     bool BuyMethod;
     bool SellMethod;

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -55,12 +55,14 @@ struct SimpleItemConfigEntry
 {
     uint32 itemID;
     uint32 numStacks;
+    uint32 stackSize;
     uint32 sellPrice;
 };
 
 struct SimpleItemAuctionTemplate
 {
     uint32 itemID;
+    uint32 stackSize;
     uint32 sellPrice;
 };
 

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -1294,8 +1294,8 @@ public:
     void InitializeSellerSimpleMode();
     void InitializeSellerAdvancedMode();
     void InitializeConfiguration();
-    void LoadValues(AHBConfig*);
     void LoadSimpleItemConfig();
+    void LoadValues(AHBConfig*);
     void LoadItemCountsSimpleMode(AHBConfig *config);
     void LoadItemCountsAdvancedMode(AHBConfig *config);
     void DecrementItemCounts(AuctionEntry* ah, uint32 itemEntry);

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -55,6 +55,13 @@ struct SimpleItemConfigEntry
 {
     uint32 itemID;
     uint32 numStacks;
+    uint32 sellPrice;
+};
+
+struct SimpleItemAuctionTemplate
+{
+    uint32 itemID;
+    uint32 sellPrice;
 };
 
 class AHBConfig

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -30,7 +30,7 @@ public:
 
     void OnBeforeAuctionHouseMgrSendAuctionSuccessfulMail(AuctionHouseMgr* /*auctionHouseMgr*/, AuctionEntry* /*auction*/, Player* owner, uint32& /*owner_accId*/, uint32& /*profit*/, bool& sendNotification, bool& updateAchievementCriteria, bool& /*sendMail*/) override
     {
-        if (owner && owner->GetGUIDLow() == auctionbot->GetAHBplayerGUID())
+        if (owner && owner->GetGUID().GetCounter() == auctionbot->GetAHBplayerGUID())
         {
             sendNotification = false;
             updateAchievementCriteria = false;
@@ -39,14 +39,14 @@ public:
 
     void OnBeforeAuctionHouseMgrSendAuctionExpiredMail(AuctionHouseMgr* /*auctionHouseMgr*/, AuctionEntry* /*auction*/, Player* owner, uint32& /*owner_accId*/, bool& sendNotification, bool& /*sendMail*/) override
     {
-        if (owner && owner->GetGUIDLow() == auctionbot->GetAHBplayerGUID())
+        if (owner && owner->GetGUID().GetCounter() == auctionbot->GetAHBplayerGUID())
             sendNotification = false;
     }
 
     void OnBeforeAuctionHouseMgrSendAuctionOutbiddedMail(AuctionHouseMgr* /*auctionHouseMgr*/, AuctionEntry* auction, Player* oldBidder, uint32& /*oldBidder_accId*/, Player* newBidder, uint32& newPrice, bool& /*sendNotification*/, bool& /*sendMail*/) override
     {
         if (oldBidder && !newBidder)
-            oldBidder->GetSession()->SendAuctionBidderNotification(auction->GetHouseId(), auction->Id, auctionbot->GetAHBplayerGUID(), newPrice, auction->GetAuctionOutBid(), auction->item_template);
+            oldBidder->GetSession()->SendAuctionBidderNotification(auction->GetHouseId(), auction->Id, ObjectGuid::Create<HighGuid::Player>(auctionbot->GetAHBplayerGUID()), newPrice, auction->GetAuctionOutBid(), auction->item_template);
     }
 
     void OnAuctionAdd(AuctionHouseObject* /*ah*/, AuctionEntry* auction) override

--- a/src/cs_ah_bot.cpp
+++ b/src/cs_ah_bot.cpp
@@ -182,7 +182,7 @@ public:
             uint32 greytg = uint32(strtoul(param1, NULL, 0));
             uint32 whitetg = uint32(strtoul(param2, NULL, 0));
             uint32 greentg = uint32(strtoul(param3, NULL, 0));
-            uint32 bluetg = uint32(strtoul(param3, NULL, 0));
+            uint32 bluetg = uint32(strtoul(param4, NULL, 0));
             uint32 purpletg = uint32(strtoul(param5, NULL, 0));
             uint32 orangetg = uint32(strtoul(param6, NULL, 0));
             uint32 yellowtg = uint32(strtoul(param7, NULL, 0));


### PR DESCRIPTION
**⚠ This has been working quite well on my small personal server for a while now, but it needs quite a bit of cleanup before I'll be comfortable making a PR to the main mod-ah-bot repo ⚠**

This PR introduces a 'Simple Seller Mode' to `mod-ah-bot`. When simple seller mode is turned on, the seller will only sell items defined in the `simpleitemconfig` table. The items will be sold according to a limited set of parameters: `itemID`, `numStacks`, `stackSize`, and `sellPrice`:
* `itemID` - The WOW Item ID of the item to sell. Look this up on a wow database like Wowhead.
* `numStacks` - How many stacks to sell. New item stacks will be added each update cycle if there are less than `numStacks` item stacks on the auction house of items matching `itemID`
* [optional] `stackSize` - If non-zero, this item will only be sold in stacks of size `stackSize`. If zero, items will be sold using the previous auction house bot behavior: according to the stack sizes set in the `mod_auctionhousebot` table.
* [optional] `sellPrice` - This price is the *per item* sell price *in copper*. If non-zero, this item will always be sold at `sellPrice`. If zero, items will be sold using the previous auction house bot behavior: (Vendor buy or sell price depending on config)*(Rarity multiplier)

This PR also contains several minor changes specific to my server's use case. I do not plan to attempt to merge them with this PR, and as such, this is flagged as a WIP + not targeting the parent `mod-ah-bot` repo.
* Always list auctions for the maximum allowed amount of time. Most listings on our auction house go unpurchased, so this reduces the amount of times we have to add new items. If I want to merge this, I'll have to put it behind a config flag.
* Don't randomize stack size. Always sell the maximum allowable stack size according to the auction house bot config. Our server was having issues with slow auction house search, so this reduces the amount of listings on the auction house for each given item type, reducing the chance for performance degredation. If I want to merge this, I'll have to put it behind a config flag.
* Add more more detail to several of log messages + correct a few minor typos to make things easier to dig through during development + testing. If I want to merge this, I'll need to go through + clean up the log messages to make sure they're useful + relevant to other people
* Add a list of default items to add to simple item config. I probably shouldn't package this as a part of the mod, but it might be useful to folks, so I could put it in something like an `examples` folder.

